### PR TITLE
Relaxation on host values used by routing

### DIFF
--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -401,16 +401,14 @@ func buildOutboundTCPListeners(mesh *proxyconfig.ProxyMeshConfig, services []*mo
 // configuration and do not utilize CDS.
 func buildInboundListeners(instances []*model.ServiceInstance,
 	mesh *proxyconfig.ProxyMeshConfig) (Listeners, Clusters) {
-	// used for shortcut domain names for hostnames
-	suffix := sharedInstanceHost(instances)
 	listeners := make(Listeners, 0, len(instances))
 	clusters := make(Clusters, 0, len(instances))
 
 	// inbound connections/requests are redirected to the endpoint address but appear to be sent
 	// to the service address
 	// assumes that endpoint addresses/ports are unique in the instance set
+	// TODO: validate that duplicated endpoints for services can be handled (e.g. above assumption)
 	for _, instance := range instances {
-		service := instance.Service
 		endpoint := instance.Endpoint
 		servicePort := endpoint.ServicePort
 		protocol := servicePort.Protocol
@@ -436,12 +434,10 @@ func buildInboundListeners(instances []*model.ServiceInstance,
 				}
 			}
 
-			host := buildVirtualHost(service, servicePort, suffix, []*HTTPRoute{route})
-
-			// insert explicit instance (pod) ip:port as a hostname field
-			host.Domains = append(host.Domains, fmt.Sprintf("%s:%d", endpoint.Address, endpoint.Port))
-			if endpoint.Port == 80 {
-				host.Domains = append(host.Domains, endpoint.Address)
+			host := &VirtualHost{
+				Name:    fmt.Sprintf("inbound|%d", endpoint.Port),
+				Domains: []string{"*"},
+				Routes:  []*HTTPRoute{route},
 			}
 
 			config := &HTTPRouteConfig{VirtualHosts: []*VirtualHost{host}}

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -350,6 +350,11 @@ func buildOutboundHTTPRoutes(
 
 				host := buildVirtualHost(service, servicePort, suffix, routes)
 				http := httpConfigs.EnsurePort(servicePort.Port)
+
+				// there should be at most one occurrence of the service for the same
+				// port since service port values are distinct; that means the virtual
+				// host domains, which include the sole domain name for the service, do
+				// not overlap for the same route config
 				http.VirtualHosts = append(http.VirtualHosts, host)
 			}
 		}

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -354,7 +354,9 @@ func buildOutboundHTTPRoutes(
 				// there should be at most one occurrence of the service for the same
 				// port since service port values are distinct; that means the virtual
 				// host domains, which include the sole domain name for the service, do
-				// not overlap for the same route config
+				// not overlap for the same route config.
+				// for example, a service "a" with two ports 80 and 8080, would have virtual
+				// hosts on 80 and 8080 listeners that contain domain "a".
 				http.VirtualHosts = append(http.VirtualHosts, host)
 			}
 		}

--- a/proxy/envoy/discovery_test.go
+++ b/proxy/envoy/discovery_test.go
@@ -205,13 +205,24 @@ func TestRouteDiscoveryAllRoutes(t *testing.T) {
 	compareResponse(response, "testdata/all-rds.json", t)
 }
 
-func TestRouteDiscovery(t *testing.T) {
+func TestRouteDiscoveryV0(t *testing.T) {
 	ds := makeDiscoveryService(t, mock.MakeRegistry())
 	url := fmt.Sprintf("/v1/routes/80/%s/%s", ds.MeshConfig.IstioServiceCluster, mock.HostInstanceV0)
 	response := makeDiscoveryRequest(ds, "GET", url, t)
 	compareResponse(response, "testdata/rds-v0.json", t)
-	url = fmt.Sprintf("/v1/routes/80/%s/%s", ds.MeshConfig.IstioServiceCluster, mock.HostInstanceV1)
-	response = makeDiscoveryRequest(ds, "GET", url, t)
+}
+
+func TestRouteDiscoveryV0Status(t *testing.T) {
+	ds := makeDiscoveryService(t, mock.MakeRegistry())
+	url := fmt.Sprintf("/v1/routes/81/%s/%s", ds.MeshConfig.IstioServiceCluster, mock.HostInstanceV0)
+	response := makeDiscoveryRequest(ds, "GET", url, t)
+	compareResponse(response, "testdata/rds-v0-status.json", t)
+}
+
+func TestRouteDiscoveryV1(t *testing.T) {
+	ds := makeDiscoveryService(t, mock.MakeRegistry())
+	url := fmt.Sprintf("/v1/routes/80/%s/%s", ds.MeshConfig.IstioServiceCluster, mock.HostInstanceV1)
+	response := makeDiscoveryRequest(ds, "GET", url, t)
 	compareResponse(response, "testdata/rds-v1.json", t)
 }
 

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -290,8 +290,6 @@ func buildIngressRoute(ingress *proxyconfig.RouteRule,
 	out := make([]*HTTPRoute, 0)
 	for _, route := range routes {
 		if applied := route.CombinePathPrefix(ingressRoute.Path, ingressRoute.Prefix); applied != nil {
-			// rewrite the host header so that inbound proxies can match incoming traffic
-			applied.HostRewrite = fmt.Sprintf("%s:%d", service.Hostname, servicePort.Port)
 			out = append(out, applied)
 		}
 	}

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -242,10 +242,10 @@ func buildVirtualHost(svc *model.Service, port *model.Port, suffix []string, rou
 	for _, host := range hosts {
 		domains = append(domains, fmt.Sprintf("%s:%d", host, port.Port))
 
-		// default port 80 does not need to be specified
-		if port.Port == 80 {
-			domains = append(domains, host)
-		}
+		// since the port on the TCP listener address matches the service port,
+		// the colon suffix is optional and is inferred.
+		// (see https://tools.ietf.org/html/rfc7230#section-5.5)
+		domains = append(domains, host)
 	}
 
 	return &VirtualHost{

--- a/proxy/envoy/testdata/all-rds.json.golden
+++ b/proxy/envoy/testdata/all-rds.json.golden
@@ -8,10 +8,15 @@
      "name": "httpsbin.default.svc.cluster.local|https",
      "domains": [
       "httpsbin:443",
+      "httpsbin",
       "httpsbin.default:443",
+      "httpsbin.default",
       "httpsbin.default.svc:443",
+      "httpsbin.default.svc",
       "httpsbin.default.svc.cluster:443",
-      "httpsbin.default.svc.cluster.local:443"
+      "httpsbin.default.svc.cluster",
+      "httpsbin.default.svc.cluster.local:443",
+      "httpsbin.default.svc.cluster.local"
      ],
      "routes": [
       {
@@ -32,10 +37,15 @@
      "name": "httpsbin.default.svc.cluster.local|https",
      "domains": [
       "httpsbin:443",
+      "httpsbin",
       "httpsbin.default:443",
+      "httpsbin.default",
       "httpsbin.default.svc:443",
+      "httpsbin.default.svc",
       "httpsbin.default.svc.cluster:443",
-      "httpsbin.default.svc.cluster.local:443"
+      "httpsbin.default.svc.cluster",
+      "httpsbin.default.svc.cluster.local:443",
+      "httpsbin.default.svc.cluster.local"
      ],
      "routes": [
       {
@@ -56,10 +66,15 @@
      "name": "httpsbin.default.svc.cluster.local|https",
      "domains": [
       "httpsbin:443",
+      "httpsbin",
       "httpsbin.default:443",
+      "httpsbin.default",
       "httpsbin.default.svc:443",
+      "httpsbin.default.svc",
       "httpsbin.default.svc.cluster:443",
-      "httpsbin.default.svc.cluster.local:443"
+      "httpsbin.default.svc.cluster",
+      "httpsbin.default.svc.cluster.local:443",
+      "httpsbin.default.svc.cluster.local"
      ],
      "routes": [
       {
@@ -80,10 +95,15 @@
      "name": "httpsbin.default.svc.cluster.local|https",
      "domains": [
       "httpsbin:443",
+      "httpsbin",
       "httpsbin.default:443",
+      "httpsbin.default",
       "httpsbin.default.svc:443",
+      "httpsbin.default.svc",
       "httpsbin.default.svc.cluster:443",
-      "httpsbin.default.svc.cluster.local:443"
+      "httpsbin.default.svc.cluster",
+      "httpsbin.default.svc.cluster.local:443",
+      "httpsbin.default.svc.cluster.local"
      ],
      "routes": [
       {
@@ -404,11 +424,17 @@
      "name": "hello.default.svc.cluster.local|http-status",
      "domains": [
       "hello:81",
+      "hello",
       "hello.default:81",
+      "hello.default",
       "hello.default.svc:81",
+      "hello.default.svc",
       "hello.default.svc.cluster:81",
+      "hello.default.svc.cluster",
       "hello.default.svc.cluster.local:81",
-      "10.1.0.0:81"
+      "hello.default.svc.cluster.local",
+      "10.1.0.0:81",
+      "10.1.0.0"
      ],
      "routes": [
       {
@@ -421,11 +447,17 @@
      "name": "world.default.svc.cluster.local|http-status",
      "domains": [
       "world:81",
+      "world",
       "world.default:81",
+      "world.default",
       "world.default.svc:81",
+      "world.default.svc",
       "world.default.svc.cluster:81",
+      "world.default.svc.cluster",
       "world.default.svc.cluster.local:81",
-      "10.2.0.0:81"
+      "world.default.svc.cluster.local",
+      "10.2.0.0:81",
+      "10.2.0.0"
      ],
      "routes": [
       {
@@ -445,11 +477,17 @@
      "name": "hello.default.svc.cluster.local|http-status",
      "domains": [
       "hello:81",
+      "hello",
       "hello.default:81",
+      "hello.default",
       "hello.default.svc:81",
+      "hello.default.svc",
       "hello.default.svc.cluster:81",
+      "hello.default.svc.cluster",
       "hello.default.svc.cluster.local:81",
-      "10.1.0.0:81"
+      "hello.default.svc.cluster.local",
+      "10.1.0.0:81",
+      "10.1.0.0"
      ],
      "routes": [
       {
@@ -462,11 +500,17 @@
      "name": "world.default.svc.cluster.local|http-status",
      "domains": [
       "world:81",
+      "world",
       "world.default:81",
+      "world.default",
       "world.default.svc:81",
+      "world.default.svc",
       "world.default.svc.cluster:81",
+      "world.default.svc.cluster",
       "world.default.svc.cluster.local:81",
-      "10.2.0.0:81"
+      "world.default.svc.cluster.local",
+      "10.2.0.0:81",
+      "10.2.0.0"
      ],
      "routes": [
       {
@@ -486,11 +530,17 @@
      "name": "hello.default.svc.cluster.local|http-status",
      "domains": [
       "hello:81",
+      "hello",
       "hello.default:81",
+      "hello.default",
       "hello.default.svc:81",
+      "hello.default.svc",
       "hello.default.svc.cluster:81",
+      "hello.default.svc.cluster",
       "hello.default.svc.cluster.local:81",
-      "10.1.0.0:81"
+      "hello.default.svc.cluster.local",
+      "10.1.0.0:81",
+      "10.1.0.0"
      ],
      "routes": [
       {
@@ -503,11 +553,17 @@
      "name": "world.default.svc.cluster.local|http-status",
      "domains": [
       "world:81",
+      "world",
       "world.default:81",
+      "world.default",
       "world.default.svc:81",
+      "world.default.svc",
       "world.default.svc.cluster:81",
+      "world.default.svc.cluster",
       "world.default.svc.cluster.local:81",
-      "10.2.0.0:81"
+      "world.default.svc.cluster.local",
+      "10.2.0.0:81",
+      "10.2.0.0"
      ],
      "routes": [
       {
@@ -527,11 +583,17 @@
      "name": "hello.default.svc.cluster.local|http-status",
      "domains": [
       "hello:81",
+      "hello",
       "hello.default:81",
+      "hello.default",
       "hello.default.svc:81",
+      "hello.default.svc",
       "hello.default.svc.cluster:81",
+      "hello.default.svc.cluster",
       "hello.default.svc.cluster.local:81",
-      "10.1.0.0:81"
+      "hello.default.svc.cluster.local",
+      "10.1.0.0:81",
+      "10.1.0.0"
      ],
      "routes": [
       {
@@ -544,11 +606,17 @@
      "name": "world.default.svc.cluster.local|http-status",
      "domains": [
       "world:81",
+      "world",
       "world.default:81",
+      "world.default",
       "world.default.svc:81",
+      "world.default.svc",
       "world.default.svc.cluster:81",
+      "world.default.svc.cluster",
       "world.default.svc.cluster.local:81",
-      "10.2.0.0:81"
+      "world.default.svc.cluster.local",
+      "10.2.0.0:81",
+      "10.2.0.0"
      ],
      "routes": [
       {

--- a/proxy/envoy/testdata/envoy-fault.json.golden
+++ b/proxy/envoy/testdata/envoy-fault.json.golden
@@ -244,15 +244,9 @@
             "route_config": {
               "virtual_hosts": [
                 {
-                  "name": "hello.default.svc.cluster.local|http-status",
+                  "name": "inbound|1081",
                   "domains": [
-                    "hello:81",
-                    "hello.default:81",
-                    "hello.default.svc:81",
-                    "hello.default.svc.cluster:81",
-                    "hello.default.svc.cluster.local:81",
-                    "10.1.0.0:81",
-                    "10.1.1.0:1081"
+                    "*"
                   ],
                   "routes": [
                     {
@@ -359,22 +353,9 @@
             "route_config": {
               "virtual_hosts": [
                 {
-                  "name": "hello.default.svc.cluster.local|http",
+                  "name": "inbound|80",
                   "domains": [
-                    "hello:80",
-                    "hello",
-                    "hello.default:80",
-                    "hello.default",
-                    "hello.default.svc:80",
-                    "hello.default.svc",
-                    "hello.default.svc.cluster:80",
-                    "hello.default.svc.cluster",
-                    "hello.default.svc.cluster.local:80",
-                    "hello.default.svc.cluster.local",
-                    "10.1.0.0:80",
-                    "10.1.0.0",
-                    "10.1.1.0:80",
-                    "10.1.1.0"
+                    "*"
                   ],
                   "routes": [
                     {

--- a/proxy/envoy/testdata/envoy-v0-auth.json.golden
+++ b/proxy/envoy/testdata/envoy-v0-auth.json.golden
@@ -180,15 +180,9 @@
             "route_config": {
               "virtual_hosts": [
                 {
-                  "name": "hello.default.svc.cluster.local|http-status",
+                  "name": "inbound|1081",
                   "domains": [
-                    "hello:81",
-                    "hello.default:81",
-                    "hello.default.svc:81",
-                    "hello.default.svc.cluster:81",
-                    "hello.default.svc.cluster.local:81",
-                    "10.1.0.0:81",
-                    "10.1.1.0:1081"
+                    "*"
                   ],
                   "routes": [
                     {
@@ -300,22 +294,9 @@
             "route_config": {
               "virtual_hosts": [
                 {
-                  "name": "hello.default.svc.cluster.local|http",
+                  "name": "inbound|80",
                   "domains": [
-                    "hello:80",
-                    "hello",
-                    "hello.default:80",
-                    "hello.default",
-                    "hello.default.svc:80",
-                    "hello.default.svc",
-                    "hello.default.svc.cluster:80",
-                    "hello.default.svc.cluster",
-                    "hello.default.svc.cluster.local:80",
-                    "hello.default.svc.cluster.local",
-                    "10.1.0.0:80",
-                    "10.1.0.0",
-                    "10.1.1.0:80",
-                    "10.1.1.0"
+                    "*"
                   ],
                   "routes": [
                     {

--- a/proxy/envoy/testdata/envoy-v0.json.golden
+++ b/proxy/envoy/testdata/envoy-v0.json.golden
@@ -180,15 +180,9 @@
             "route_config": {
               "virtual_hosts": [
                 {
-                  "name": "hello.default.svc.cluster.local|http-status",
+                  "name": "inbound|1081",
                   "domains": [
-                    "hello:81",
-                    "hello.default:81",
-                    "hello.default.svc:81",
-                    "hello.default.svc.cluster:81",
-                    "hello.default.svc.cluster.local:81",
-                    "10.1.0.0:81",
-                    "10.1.1.0:1081"
+                    "*"
                   ],
                   "routes": [
                     {
@@ -295,22 +289,9 @@
             "route_config": {
               "virtual_hosts": [
                 {
-                  "name": "hello.default.svc.cluster.local|http",
+                  "name": "inbound|80",
                   "domains": [
-                    "hello:80",
-                    "hello",
-                    "hello.default:80",
-                    "hello.default",
-                    "hello.default.svc:80",
-                    "hello.default.svc",
-                    "hello.default.svc.cluster:80",
-                    "hello.default.svc.cluster",
-                    "hello.default.svc.cluster.local:80",
-                    "hello.default.svc.cluster.local",
-                    "10.1.0.0:80",
-                    "10.1.0.0",
-                    "10.1.1.0:80",
-                    "10.1.1.0"
+                    "*"
                   ],
                   "routes": [
                     {

--- a/proxy/envoy/testdata/envoy-v1-auth.json.golden
+++ b/proxy/envoy/testdata/envoy-v1-auth.json.golden
@@ -180,15 +180,9 @@
             "route_config": {
               "virtual_hosts": [
                 {
-                  "name": "hello.default.svc.cluster.local|http-status",
+                  "name": "inbound|1081",
                   "domains": [
-                    "hello:81",
-                    "hello.default:81",
-                    "hello.default.svc:81",
-                    "hello.default.svc.cluster:81",
-                    "hello.default.svc.cluster.local:81",
-                    "10.1.0.0:81",
-                    "10.1.1.1:1081"
+                    "*"
                   ],
                   "routes": [
                     {
@@ -300,22 +294,9 @@
             "route_config": {
               "virtual_hosts": [
                 {
-                  "name": "hello.default.svc.cluster.local|http",
+                  "name": "inbound|80",
                   "domains": [
-                    "hello:80",
-                    "hello",
-                    "hello.default:80",
-                    "hello.default",
-                    "hello.default.svc:80",
-                    "hello.default.svc",
-                    "hello.default.svc.cluster:80",
-                    "hello.default.svc.cluster",
-                    "hello.default.svc.cluster.local:80",
-                    "hello.default.svc.cluster.local",
-                    "10.1.0.0:80",
-                    "10.1.0.0",
-                    "10.1.1.1:80",
-                    "10.1.1.1"
+                    "*"
                   ],
                   "routes": [
                     {

--- a/proxy/envoy/testdata/envoy-v1.json.golden
+++ b/proxy/envoy/testdata/envoy-v1.json.golden
@@ -180,15 +180,9 @@
             "route_config": {
               "virtual_hosts": [
                 {
-                  "name": "hello.default.svc.cluster.local|http-status",
+                  "name": "inbound|1081",
                   "domains": [
-                    "hello:81",
-                    "hello.default:81",
-                    "hello.default.svc:81",
-                    "hello.default.svc.cluster:81",
-                    "hello.default.svc.cluster.local:81",
-                    "10.1.0.0:81",
-                    "10.1.1.1:1081"
+                    "*"
                   ],
                   "routes": [
                     {
@@ -295,22 +289,9 @@
             "route_config": {
               "virtual_hosts": [
                 {
-                  "name": "hello.default.svc.cluster.local|http",
+                  "name": "inbound|80",
                   "domains": [
-                    "hello:80",
-                    "hello",
-                    "hello.default:80",
-                    "hello.default",
-                    "hello.default.svc:80",
-                    "hello.default.svc",
-                    "hello.default.svc.cluster:80",
-                    "hello.default.svc.cluster",
-                    "hello.default.svc.cluster.local:80",
-                    "hello.default.svc.cluster.local",
-                    "10.1.0.0:80",
-                    "10.1.0.0",
-                    "10.1.1.1:80",
-                    "10.1.1.1"
+                    "*"
                   ],
                   "routes": [
                     {

--- a/proxy/envoy/testdata/rds-ingress-ssl.json.golden
+++ b/proxy/envoy/testdata/rds-ingress-ssl.json.golden
@@ -8,7 +8,6 @@
     "routes": [
      {
       "prefix": "/bar",
-      "host_rewrite": "hello.default.svc.cluster.local:81",
       "cluster": "out.81c187d71467b1608736c57bb0734f9ef9b68f7d"
      }
     ]

--- a/proxy/envoy/testdata/rds-ingress-weighted.json.golden
+++ b/proxy/envoy/testdata/rds-ingress-weighted.json.golden
@@ -8,7 +8,6 @@
     "routes": [
      {
       "path": "/hello",
-      "host_rewrite": "world.default.svc.cluster.local:80",
       "weighted_clusters": {
        "clusters": [
         {

--- a/proxy/envoy/testdata/rds-ingress.json.golden
+++ b/proxy/envoy/testdata/rds-ingress.json.golden
@@ -8,7 +8,6 @@
     "routes": [
      {
       "path": "/hello",
-      "host_rewrite": "world.default.svc.cluster.local:80",
       "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
      }
     ]

--- a/proxy/envoy/testdata/rds-v0-status.json.golden
+++ b/proxy/envoy/testdata/rds-v0-status.json.golden
@@ -1,0 +1,50 @@
+{
+  "virtual_hosts": [
+   {
+    "name": "hello.default.svc.cluster.local|http-status",
+    "domains": [
+     "hello:81",
+     "hello",
+     "hello.default:81",
+     "hello.default",
+     "hello.default.svc:81",
+     "hello.default.svc",
+     "hello.default.svc.cluster:81",
+     "hello.default.svc.cluster",
+     "hello.default.svc.cluster.local:81",
+     "hello.default.svc.cluster.local",
+     "10.1.0.0:81",
+     "10.1.0.0"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.81c187d71467b1608736c57bb0734f9ef9b68f7d"
+     }
+    ]
+   },
+   {
+    "name": "world.default.svc.cluster.local|http-status",
+    "domains": [
+     "world:81",
+     "world",
+     "world.default:81",
+     "world.default",
+     "world.default.svc:81",
+     "world.default.svc",
+     "world.default.svc.cluster:81",
+     "world.default.svc.cluster",
+     "world.default.svc.cluster.local:81",
+     "world.default.svc.cluster.local",
+     "10.2.0.0:81",
+     "10.2.0.0"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.bde94496eb59ec2ed5b81392a1d32377960660b8"
+     }
+    ]
+   }
+  ]
+ }


### PR DESCRIPTION
Relaxation on the authority field values used for routing:
- inbound HTTP listeners will not require the host matches the service name
- outbound HTTP listeners will not require colon + port suffix
- ingress proxy does not override authority header

Ref https://github.com/istio/issues/issues/8
Ref #791 