### PR TITLE
Add support for statsd export

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -305,7 +305,7 @@ new_go_repository(
 ## Proxy build rules
 ##
 
-PROXY = "35b64109abe5c2242d5548507edb4c5912c43198"  # Jun 1, 2017
+PROXY = "466a7346f3c2c2f3cbcb0f1a74d2cd9ac6a565fe"  # Jun 2, 2017
 
 http_file(
     name = "istio_proxy",
@@ -405,7 +405,7 @@ go_proto_library(
     ],
 )
     """,
-    commit = "6e481630954efcad10c0ab43244e8991a5a36bfc",  # May 5 2017
+    commit = "94aa4ce91ada31c401f407324fec6cf1a6b52b02",  # June 2, 2017
     remote = "https://github.com/istio/api.git",
 )
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/golang/glog"
@@ -58,24 +57,6 @@ func GetMeshConfig(kube kubernetes.Interface, namespace, name string) (*proxycon
 	mesh := proxy.DefaultMeshConfig()
 	if err = model.ApplyYAML(yaml, &mesh); err != nil {
 		return nil, multierror.Prefix(err, "failed to convert to proto.")
-	}
-
-	if mesh.MixerAddress != "" && mesh.StatsdUdpAddress == "" {
-		colon := strings.Index(mesh.MixerAddress, ":")
-		mixerAddr := mesh.MixerAddress[:colon]
-		if ipErr := model.ValidateIPv4Address(mixerAddr); ipErr == nil {
-			mesh.StatsdUdpAddress = mesh.MixerAddress
-		} else {
-			if mixerSvc, kubeErr := kube.CoreV1().Services(namespace).Get(mixerAddr, v1.GetOptions{}); kubeErr == nil {
-				port := int32(9125)
-				for _, sp := range mixerSvc.Spec.Ports {
-					if sp.Protocol == "UDP" && strings.Contains(sp.Name, "statsd") {
-						port = sp.Port
-					}
-				}
-				mesh.StatsdUdpAddress = fmt.Sprintf("%s:%d", mixerSvc.Spec.ClusterIP, port)
-			}
-		}
 	}
 
 	if err = model.ValidateProxyMeshConfig(&mesh); err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -63,10 +63,10 @@ func GetMeshConfig(kube kubernetes.Interface, namespace, name string) (*proxycon
 	if mesh.MixerAddress != "" && mesh.StatsdUdpAddress == "" {
 		colon := strings.Index(mesh.MixerAddress, ":")
 		mixerAddr := mesh.MixerAddress[:colon]
-		if err := model.ValidateIPv4Address(mixerAddr); err == nil {
+		if ipErr := model.ValidateIPv4Address(mixerAddr); ipErr == nil {
 			mesh.StatsdUdpAddress = mesh.MixerAddress
 		} else {
-			if mixerSvc, err := kube.CoreV1().Services(namespace).Get(mixerAddr, v1.GetOptions{}); err == nil {
+			if mixerSvc, kubeErr := kube.CoreV1().Services(namespace).Get(mixerAddr, v1.GetOptions{}); kubeErr == nil {
 				port := int32(9125)
 				for _, sp := range mixerSvc.Spec.Ports {
 					if sp.Protocol == "UDP" && strings.Contains(sp.Name, "statsd") {

--- a/model/validation.go
+++ b/model/validation.go
@@ -806,6 +806,28 @@ func ValidateProxyAddress(hostAddr string) error {
 	return nil
 }
 
+// ValidateIPv4AddressAndPort checks that a network address is well-formed.
+// This works just like ValidateProxyAddress, but without support for FQDNs.
+func ValidateIPv4AddressAndPort(hostAddr string) error {
+	colon := strings.Index(hostAddr, ":")
+	if colon < 0 {
+		return fmt.Errorf("':' separator not found in %q, host address must be of the form of <IP>:<port>",
+			hostAddr)
+	}
+	port, err := strconv.Atoi(hostAddr[colon+1:])
+	if err != nil {
+		return err
+	}
+	if err = ValidatePort(port); err != nil {
+		return err
+	}
+	host := hostAddr[:colon]
+	if err = ValidateIPv4Address(host); err != nil {
+		return fmt.Errorf("%q is not a valid IPv4 address", host)
+	}
+	return nil
+}
+
 // ValidateDuration checks that a proto duration is well-formed
 func ValidateDuration(pd *duration.Duration) error {
 	dur, err := ptypes.Duration(pd)
@@ -915,6 +937,12 @@ func ValidateProxyMeshConfig(mesh *proxyconfig.ProxyMeshConfig) (errs error) {
 	if mesh.MixerAddress != "" {
 		if err := ValidateProxyAddress(mesh.MixerAddress); err != nil {
 			errs = multierror.Append(errs, multierror.Prefix(err, "invalid Mixer address:"))
+		}
+	}
+
+	if mesh.StatsdUdpAddress != "" {
+		if err := ValidateIPv4AddressAndPort(mesh.StatsdUdpAddress); err != nil {
+			errs = multierror.Append(errs, multierror.Prefix(err, "invalid statsd udp address:"))
 		}
 	}
 

--- a/model/validation.go
+++ b/model/validation.go
@@ -806,28 +806,6 @@ func ValidateProxyAddress(hostAddr string) error {
 	return nil
 }
 
-// ValidateIPv4AddressAndPort checks that a network address is well-formed.
-// This works just like ValidateProxyAddress, but without support for FQDNs.
-func ValidateIPv4AddressAndPort(hostAddr string) error {
-	colon := strings.Index(hostAddr, ":")
-	if colon < 0 {
-		return fmt.Errorf("':' separator not found in %q, host address must be of the form of <IP>:<port>",
-			hostAddr)
-	}
-	port, err := strconv.Atoi(hostAddr[colon+1:])
-	if err != nil {
-		return err
-	}
-	if err = ValidatePort(port); err != nil {
-		return err
-	}
-	host := hostAddr[:colon]
-	if err = ValidateIPv4Address(host); err != nil {
-		return fmt.Errorf("%q is not a valid IPv4 address", host)
-	}
-	return nil
-}
-
 // ValidateDuration checks that a proto duration is well-formed
 func ValidateDuration(pd *duration.Duration) error {
 	dur, err := ptypes.Duration(pd)
@@ -941,7 +919,7 @@ func ValidateProxyMeshConfig(mesh *proxyconfig.ProxyMeshConfig) (errs error) {
 	}
 
 	if mesh.StatsdUdpAddress != "" {
-		if err := ValidateIPv4AddressAndPort(mesh.StatsdUdpAddress); err != nil {
+		if err := ValidateProxyAddress(mesh.StatsdUdpAddress); err != nil {
 			errs = multierror.Append(errs, multierror.Prefix(err, "invalid statsd udp address:"))
 		}
 	}

--- a/model/validation_test.go
+++ b/model/validation_test.go
@@ -852,6 +852,7 @@ func TestValidateProxyMeshConfig(t *testing.T) {
 		IstioServiceCluster:    "",
 		AuthPolicy:             -1,
 		AuthCertsPath:          "",
+		StatsdUdpAddress:       "10.0.0.100",
 	}
 
 	err := ValidateProxyMeshConfig(&invalid)
@@ -861,7 +862,7 @@ func TestValidateProxyMeshConfig(t *testing.T) {
 		switch err.(type) {
 		case *multierror.Error:
 			// each field must cause an error in the field
-			if len(err.(*multierror.Error).Errors) < 12 {
+			if len(err.(*multierror.Error).Errors) < 13 {
 				t.Errorf("expected an error for each field %v", err)
 			}
 		default:

--- a/proxy/envoy/BUILD
+++ b/proxy/envoy/BUILD
@@ -11,6 +11,7 @@ go_library(
         "header.go",
         "ingress.go",
         "policy.go",
+        "resolve.go",
         "resources.go",
         "route.go",
         "watcher.go",

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -15,14 +15,10 @@
 package envoy
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"os"
-	"strings"
-	"time"
 
 	"github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
@@ -113,21 +109,7 @@ func buildConfig(listeners Listeners, clusters Clusters, mesh *proxyconfig.Proxy
 				RefreshDelayMs: protoDurationToMS(mesh.DiscoveryRefreshDelay),
 			},
 		},
-	}
-
-	if mesh.StatsdUdpAddress != "" {
-		colon := strings.Index(mesh.StatsdUdpAddress, ":")
-		statsdAddr := mesh.StatsdUdpAddress[:colon]
-		statsdPort := mesh.StatsdUdpAddress[colon:]
-		glog.Infof("Attempting to lookup statsd address: %s", statsdAddr)
-		// lookup the statsd udp address with a timeout of 5 seconds.
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if addrs, lookupErr := net.DefaultResolver.LookupIPAddr(ctx, statsdAddr); lookupErr == nil {
-			out.StatsdUDPIPAddress = fmt.Sprintf("%s%s", addrs[0].IP, statsdPort)
-			glog.Infof("Statsd Addr: %s", out.StatsdUDPIPAddress)
-		}
-		glog.Infof("Finished lookup of statsd address: %s", statsdAddr)
+		StatsdUDPIPAddress: mesh.StatsdUdpAddress,
 	}
 
 	if mesh.ZipkinAddress != "" {

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -121,7 +121,8 @@ func buildConfig(listeners Listeners, clusters Clusters, mesh *proxyconfig.Proxy
 		statsdPort := mesh.StatsdUdpAddress[colon:]
 		glog.Infof("Attempting to lookup statsd address: %s", statsdAddr)
 		// lookup the statsd udp address with a timeout of 5 seconds.
-		ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		if addrs, lookupErr := net.DefaultResolver.LookupIPAddr(ctx, statsdAddr); lookupErr == nil {
 			out.StatsdUDPIPAddress = fmt.Sprintf("%s%s", addrs[0].IP, statsdPort)
 			glog.Infof("Statsd Addr: %s", out.StatsdUDPIPAddress)

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -111,6 +111,10 @@ func buildConfig(listeners Listeners, clusters Clusters, mesh *proxyconfig.Proxy
 		},
 	}
 
+	if mesh.StatsdUdpAddress != "" {
+		out.StatsdUDPIPAddress = mesh.StatsdUdpAddress
+	}
+
 	if mesh.ZipkinAddress != "" {
 		out.ClusterManager.Clusters = append(out.ClusterManager.Clusters,
 			buildCluster(mesh.ZipkinAddress, ZipkinCollectorCluster, mesh.ConnectTimeout))

--- a/proxy/envoy/config_test.go
+++ b/proxy/envoy/config_test.go
@@ -344,6 +344,7 @@ func makeMeshConfig() proxyconfig.ProxyMeshConfig {
 	mesh.DiscoveryAddress = "localhost:8080"
 	mesh.DiscoveryRefreshDelay = ptypes.DurationProto(10 * time.Millisecond)
 	mesh.EgressProxyAddress = "localhost:8888"
+	mesh.StatsdUdpAddress = "10.1.1.10:9125"
 	return mesh
 }
 

--- a/proxy/envoy/egress.go
+++ b/proxy/envoy/egress.go
@@ -45,7 +45,7 @@ func NewEgressWatcher(mesh *proxyconfig.ProxyMeshConfig) (Watcher, error) {
 		if addr, err := resolveStatsdAddr(mesh.StatsdUdpAddress); err == nil {
 			mesh.StatsdUdpAddress = addr
 		} else {
-			glog.V(2).Infof("Error resolving statsd address; clearing to prevent bad config: %v", err)
+			glog.Warningf("Error resolving statsd address; clearing to prevent bad config: %v", err)
 			mesh.StatsdUdpAddress = ""
 		}
 	}

--- a/proxy/envoy/egress.go
+++ b/proxy/envoy/egress.go
@@ -41,6 +41,14 @@ func NewEgressWatcher(mesh *proxyconfig.ProxyMeshConfig) (Watcher, error) {
 	if mesh.EgressProxyAddress == "" {
 		return nil, errors.New("egress proxy requires address configuration")
 	}
+	if mesh.StatsdUdpAddress != "" {
+		if addr, err := resolveStatsdAddr(mesh.StatsdUdpAddress); err == nil {
+			mesh.StatsdUdpAddress = addr
+		} else {
+			glog.V(2).Infof("Error resolving statsd address; clearing to prevent bad config: %v", err)
+			mesh.StatsdUdpAddress = ""
+		}
+	}
 	agent := proxy.NewAgent(runEnvoy(mesh, egressNode), proxy.DefaultRetry)
 	return &egressWatcher{
 		agent: agent,

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -52,7 +52,7 @@ func NewIngressWatcher(mesh *proxyconfig.ProxyMeshConfig, secrets model.SecretRe
 		if addr, err := resolveStatsdAddr(mesh.StatsdUdpAddress); err == nil {
 			mesh.StatsdUdpAddress = addr
 		} else {
-			glog.V(2).Infof("Error resolving statsd address; clearing to prevent bad config: %v", err)
+			glog.Warningf("Error resolving statsd address; clearing to prevent bad config: %v", err)
 			mesh.StatsdUdpAddress = ""
 		}
 	}

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -48,6 +48,14 @@ type ingressWatcher struct {
 
 // NewIngressWatcher creates a new ingress watcher instance with an agent
 func NewIngressWatcher(mesh *proxyconfig.ProxyMeshConfig, secrets model.SecretRegistry) (Watcher, error) {
+	if mesh.StatsdUdpAddress != "" {
+		if addr, err := resolveStatsdAddr(mesh.StatsdUdpAddress); err == nil {
+			mesh.StatsdUdpAddress = addr
+		} else {
+			glog.V(2).Infof("Error resolving statsd address; clearing to prevent bad config: %v", err)
+			mesh.StatsdUdpAddress = ""
+		}
+	}
 	agent := proxy.NewAgent(runEnvoy(mesh, ingressNode), proxy.DefaultRetry)
 	out := &ingressWatcher{
 		agent:   agent,

--- a/proxy/envoy/resolve.go
+++ b/proxy/envoy/resolve.go
@@ -1,0 +1,32 @@
+package envoy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+func resolveStatsdAddr(statsdAdrr string) (string, error) {
+	if statsdAdrr == "" {
+		return "", nil
+	}
+	colon := strings.Index(statsdAdrr, ":")
+	host := statsdAdrr[:colon]
+	port := statsdAdrr[colon:]
+	glog.Infof("Attempting to lookup statsd address: %s", host)
+	defer glog.Infof("Finished lookup of statsd address: %s", host)
+	// lookup the statsd udp address with a timeout of 15 seconds.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	addrs, lookupErr := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if lookupErr != nil {
+		return "", fmt.Errorf("lookup failed for statsd udp address: %v", lookupErr)
+	}
+	resolvedAddr := fmt.Sprintf("%s%s", addrs[0].IP, port)
+	glog.Infof("Statsd Addr: %s", resolvedAddr)
+	return resolvedAddr, nil
+}

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -98,11 +98,12 @@ func protoDurationToMS(dur *duration.Duration) int64 {
 
 // Config defines the schema for Envoy JSON configuration format
 type Config struct {
-	RootRuntime    *RootRuntime   `json:"runtime,omitempty"`
-	Listeners      Listeners      `json:"listeners"`
-	Admin          Admin          `json:"admin"`
-	ClusterManager ClusterManager `json:"cluster_manager"`
-	Tracing        *Tracing       `json:"tracing,omitempty"`
+	RootRuntime        *RootRuntime   `json:"runtime,omitempty"`
+	Listeners          Listeners      `json:"listeners"`
+	Admin              Admin          `json:"admin"`
+	ClusterManager     ClusterManager `json:"cluster_manager"`
+	StatsdUDPIPAddress string         `json:"statsd_udp_ip_address,omitempty"`
+	Tracing            *Tracing       `json:"tracing,omitempty"`
 	// Special value used to hash all referenced values (e.g. TLS secrets)
 	Hash []byte `json:"-"`
 }

--- a/proxy/envoy/testdata/envoy-egress-auth.json.golden
+++ b/proxy/envoy/testdata/envoy-egress-auth.json.golden
@@ -84,5 +84,6 @@
       },
       "refresh_delay_ms": 10
     }
-  }
+  },
+  "statsd_udp_ip_address": "10.1.1.10:9125"
 }

--- a/proxy/envoy/testdata/envoy-egress.json.golden
+++ b/proxy/envoy/testdata/envoy-egress.json.golden
@@ -79,5 +79,6 @@
       },
       "refresh_delay_ms": 10
     }
-  }
+  },
+  "statsd_udp_ip_address": "10.1.1.10:9125"
 }

--- a/proxy/envoy/testdata/envoy-fault.json.golden
+++ b/proxy/envoy/testdata/envoy-fault.json.golden
@@ -555,5 +555,6 @@
       },
       "refresh_delay_ms": 10
     }
-  }
+  },
+  "statsd_udp_ip_address": "10.1.1.10:9125"
 }

--- a/proxy/envoy/testdata/envoy-ingress.json.golden
+++ b/proxy/envoy/testdata/envoy-ingress.json.golden
@@ -117,5 +117,6 @@
       },
       "refresh_delay_ms": 10
     }
-  }
+  },
+  "statsd_udp_ip_address": "10.1.1.10:9125"
 }

--- a/proxy/envoy/testdata/envoy-v0-auth.json.golden
+++ b/proxy/envoy/testdata/envoy-v0-auth.json.golden
@@ -501,5 +501,6 @@
       },
       "refresh_delay_ms": 10
     }
-  }
+  },
+  "statsd_udp_ip_address": "10.1.1.10:9125"
 }

--- a/proxy/envoy/testdata/envoy-v0.json.golden
+++ b/proxy/envoy/testdata/envoy-v0.json.golden
@@ -491,5 +491,6 @@
       },
       "refresh_delay_ms": 10
     }
-  }
+  },
+  "statsd_udp_ip_address": "10.1.1.10:9125"
 }

--- a/proxy/envoy/testdata/envoy-v1-auth.json.golden
+++ b/proxy/envoy/testdata/envoy-v1-auth.json.golden
@@ -501,5 +501,6 @@
       },
       "refresh_delay_ms": 10
     }
-  }
+  },
+  "statsd_udp_ip_address": "10.1.1.10:9125"
 }

--- a/proxy/envoy/testdata/envoy-v1.json.golden
+++ b/proxy/envoy/testdata/envoy-v1.json.golden
@@ -491,5 +491,6 @@
       },
       "refresh_delay_ms": 10
     }
-  }
+  },
+  "statsd_udp_ip_address": "10.1.1.10:9125"
 }

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -47,7 +47,7 @@ func NewWatcher(ctl model.Controller, proxyCtx *proxy.Context) (Watcher, error) 
 		if addr, err := resolveStatsdAddr(proxyCtx.MeshConfig.StatsdUdpAddress); err == nil {
 			proxyCtx.MeshConfig.StatsdUdpAddress = addr
 		} else {
-			glog.V(2).Infof("Error resolving statsd address; clearing to prevent bad config: %v", err)
+			glog.Warningf("Error resolving statsd address; clearing to prevent bad config: %v", err)
 			proxyCtx.MeshConfig.StatsdUdpAddress = ""
 		}
 	}

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -40,16 +40,25 @@ type watcher struct {
 }
 
 // NewWatcher creates a new watcher instance with an agent
-func NewWatcher(ctl model.Controller, context *proxy.Context) (Watcher, error) {
-	glog.V(2).Infof("Local instance address: %s", context.IPAddress)
+func NewWatcher(ctl model.Controller, proxyCtx *proxy.Context) (Watcher, error) {
+	glog.V(2).Infof("Local instance address: %s", proxyCtx.IPAddress)
+
+	if proxyCtx.MeshConfig.StatsdUdpAddress != "" {
+		if addr, err := resolveStatsdAddr(proxyCtx.MeshConfig.StatsdUdpAddress); err == nil {
+			proxyCtx.MeshConfig.StatsdUdpAddress = addr
+		} else {
+			glog.V(2).Infof("Error resolving statsd address; clearing to prevent bad config: %v", err)
+			proxyCtx.MeshConfig.StatsdUdpAddress = ""
+		}
+	}
 
 	// Use proxy node IP as the node name
 	// This parameter is used as the value for "service-node"
-	agent := proxy.NewAgent(runEnvoy(context.MeshConfig, context.IPAddress), proxy.DefaultRetry)
+	agent := proxy.NewAgent(runEnvoy(proxyCtx.MeshConfig, proxyCtx.IPAddress), proxy.DefaultRetry)
 
 	out := &watcher{
 		agent:   agent,
-		context: context,
+		context: proxyCtx,
 		ctl:     ctl,
 	}
 


### PR DESCRIPTION
The goal of this PR is to enable collection of proxy stats. This PR focuses on generating envoy configs to direct statsd output.

This PR updates the proxy agent and the manager to support a new field in the mesh config: `statsd_udp_address`. The initial default option is to generate this address from the IP address of Mixer and the configured statsd-udp port (defaults to 9125).

Tested on new deployments. A PR to istio/istio that updates the deployment configs for mixer, pilot, and prometheus will follow.

This has a current weakness: if mixer service is deleted and restarted, export will stop working, as the `statsd_udp_address` is not regenerated in response.