### PR TITLE
use_remote_address for ingress

### DIFF
--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -171,7 +171,7 @@ func buildListeners(context *proxy.Context) (Listeners, Clusters) {
 // Use "0.0.0.0" IP address to listen on all interfaces
 // RDS parameter controls whether to use RDS for the route updates.
 func buildHTTPListener(mesh *proxyconfig.ProxyMeshConfig, routeConfig *HTTPRouteConfig,
-	ip string, port int, rds bool) *Listener {
+	ip string, port int, rds bool, useRemoteAddress bool) *Listener {
 	filters := buildFaultFilters(routeConfig)
 
 	filters = append(filters, HTTPFilter{
@@ -183,6 +183,7 @@ func buildHTTPListener(mesh *proxyconfig.ProxyMeshConfig, routeConfig *HTTPRoute
 	config := &HTTPFilterConfig{
 		CodecType:         auto,
 		GenerateRequestID: true,
+		UseRemoteAddress:  useRemoteAddress,
 		StatPrefix:        "http",
 		AccessLog: []AccessLog{{
 			Path: DefaultAccessLog,
@@ -248,7 +249,7 @@ func buildOutboundListeners(instances []*model.ServiceInstance, services []*mode
 	listeners, clusters := buildOutboundTCPListeners(context.MeshConfig, services)
 
 	for port, routeConfig := range httpOutbound {
-		listeners = append(listeners, buildHTTPListener(context.MeshConfig, routeConfig, WildcardAddress, port, true))
+		listeners = append(listeners, buildHTTPListener(context.MeshConfig, routeConfig, WildcardAddress, port, true, false))
 	}
 	return listeners, clusters
 }
@@ -449,7 +450,7 @@ func buildInboundListeners(instances []*model.ServiceInstance,
 
 			config := &HTTPRouteConfig{VirtualHosts: []*VirtualHost{host}}
 			listeners = append(listeners,
-				applyInboundAuth(buildHTTPListener(mesh, config, endpoint.Address, endpoint.Port, false), mesh))
+				applyInboundAuth(buildHTTPListener(mesh, config, endpoint.Address, endpoint.Port, false, false), mesh))
 
 		case model.ProtocolTCP, model.ProtocolHTTPS:
 			listeners = append(listeners, buildTCPListener(&TCPRouteConfig{

--- a/proxy/envoy/egress.go
+++ b/proxy/envoy/egress.go
@@ -67,7 +67,7 @@ func getEgressProxyPort(mesh *proxyconfig.ProxyMeshConfig) int {
 
 func generateEgress(mesh *proxyconfig.ProxyMeshConfig) *Config {
 	port := getEgressProxyPort(mesh)
-	listener := buildHTTPListener(mesh, nil, WildcardAddress, port, true)
+	listener := buildHTTPListener(mesh, nil, WildcardAddress, port, true, false)
 	listener = applyInboundAuth(listener, mesh)
 	config := buildConfig([]*Listener{listener}, nil, mesh)
 	if mesh.AuthPolicy == proxyconfig.ProxyMeshConfig_MUTUAL_TLS {

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -130,14 +130,14 @@ func fetchSecret(ctx context.Context, client *http.Client, url string,
 // generateIngress generates ingress proxy configuration
 func generateIngress(mesh *proxyconfig.ProxyMeshConfig, tls *model.TLSSecret, certFile, keyFile string) *Config {
 	listeners := []*Listener{
-		buildHTTPListener(mesh, nil, WildcardAddress, 80, true),
+		buildHTTPListener(mesh, nil, WildcardAddress, 80, true, true),
 	}
 
 	if tls != nil {
 		if err := writeTLS(certFile, keyFile, tls); err != nil {
 			glog.Warning("Failed to write cert/key")
 		} else {
-			listener := buildHTTPListener(mesh, nil, WildcardAddress, 443, true)
+			listener := buildHTTPListener(mesh, nil, WildcardAddress, 443, true, true)
 			listener.SSLContext = &SSLContext{
 				CertChainFile:  certFile,
 				PrivateKeyFile: keyFile,

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -371,6 +371,7 @@ type HTTPFilterConfig struct {
 	CodecType         string                 `json:"codec_type"`
 	StatPrefix        string                 `json:"stat_prefix"`
 	GenerateRequestID bool                   `json:"generate_request_id,omitempty"`
+	UseRemoteAddress  bool                   `json:"use_remote_address,omitempty"`
 	Tracing           *HTTPFilterTraceConfig `json:"tracing,omitempty"`
 	RouteConfig       *HTTPRouteConfig       `json:"route_config,omitempty"`
 	RDS               *RDS                   `json:"rds,omitempty"`

--- a/proxy/envoy/testdata/envoy-ingress.json.golden
+++ b/proxy/envoy/testdata/envoy-ingress.json.golden
@@ -10,6 +10,7 @@
             "codec_type": "auto",
             "stat_prefix": "http",
             "generate_request_id": true,
+            "use_remote_address": true,
             "rds": {
               "cluster": "rds",
               "route_config_name": "80",
@@ -42,6 +43,7 @@
             "codec_type": "auto",
             "stat_prefix": "http",
             "generate_request_id": true,
+            "use_remote_address": true,
             "rds": {
               "cluster": "rds",
               "route_config_name": "443",

--- a/test/integration/ingress.go
+++ b/test/integration/ingress.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 
@@ -114,6 +115,11 @@ func (t *ingress) run() error {
 						return nil
 					}
 				} else if len(resp.id) > 0 {
+					if !strings.Contains(resp.body, "X-Forwarded-For") {
+						glog.Warning("Missing X-Forwarded-For")
+						return errAgain
+					}
+
 					id := resp.id[0]
 					t.logs.add(dst, id, name)
 					t.logs.add("ingress", id, name)


### PR DESCRIPTION
Enable updating `x-forwarded-for` on the ingress proxy.
The sidecar proxy passes the header unmodified (documented in Envoy and validated with a test).

cc @saturnism