### PR TITLE
Update workspace to new bazel_rules_go to fix gazelle performance

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "com_github_istio_pilot")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "03c634753160632c00f506afeafc819fbea4c422",  # 5 June 2017
+    commit = "e1786dae19beb746bc9a6b9aabc2e134151d0182",  # 8 June 2017
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "com_github_istio_pilot")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "78d030fc16e7c6e0a188714980db0b04086c4a5e",  # April 12 2017 (0.4.3)
+    commit = "03c634753160632c00f506afeafc819fbea4c422",  # 5 June 2017
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 
@@ -34,7 +34,7 @@ new_go_repository(
 
 new_go_repository(
     name = "com_github_coreos_go_oidc",
-    commit = "be73733bb8cc830d0205609b95d125215f8e9c70",
+    commit = "c797a55f1c1001ec3169f1d0fbb4c5523563bec6",
     importpath = "github.com/coreos/go-oidc",
 )
 
@@ -275,6 +275,12 @@ new_go_repository(
     name = "com_github_spf13_cobra",
     commit = "9c28e4bbd74e5c3ed7aacbc552b2cab7cfdfe744",
     importpath = "github.com/spf13/cobra",
+)
+
+new_go_repository(
+    name = "com_github_inconshreveable_mousetrap",
+    commit = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75",
+    importpath = "github.com/inconshreveable/mousetrap",
 )
 
 new_go_repository(

--- a/bin/gazelle
+++ b/bin/gazelle
@@ -10,5 +10,5 @@ gazelle -go_prefix "istio.io/pilot" -mode fix
 # rewrite auto-generated protobuf dependencies due to custom BUILD files in WORKSPACE.
 find . -type f -name BUILD -print0 | \
     xargs -0 sed -i \
-	  -e 's|proxy/v1/config:go_default_library|:go_default_library|g' \
-	  -e 's|google/rpc:go_default_library|:go_default_library|g'
+         -e 's|proxy/v1/config:go_default_library|:go_default_library|g' \
+         -e 's|google/rpc:go_default_library|:go_default_library|g'


### PR DESCRIPTION
This update is to fix Gazelle performance issues when fetching `k8s.io/ingress`

Not sure whats going on with the gazelle file.

Signed-off-by: Liam White <liamwhite@uk.ibm.com>