### PR TITLE
Increase test coverage of config store

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,3 @@ load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
 
 go_prefix("istio.io/pilot")
 
-exports_files(
-    ["kube-inject-versions"],
-    visibility = ["//visibility:public"],
-)

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,3 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
 
 go_prefix("istio.io/pilot")
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -415,35 +415,6 @@ go_proto_library(
     remote = "https://github.com/istio/api.git",
 )
 
-GOOGLEAPIS_BUILD_FILE = """
-package(default_visibility = ["//visibility:public"])
-
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
-load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
-go_prefix("github.com/googleapis/googleapis/google/rpc")
-
-go_proto_library(
-    name = "go_default_library",
-    srcs = [
-        "google/rpc/code.proto",
-        "google/rpc/error_details.proto",
-        "google/rpc/status.proto",
-    ],
-    deps = [
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-    ],
-)
-"""
-
-new_git_repository(
-    name = "com_github_googleapis_googleapis",
-    build_file_content = GOOGLEAPIS_BUILD_FILE,
-    commit = "13ac2436c5e3d568bd0e938f6ed58b77a48aba15",  # Oct 21, 2016 (only release pre-dates sha)
-    remote = "https://github.com/googleapis/googleapis.git",
-)
-
 ##
 ## Mock codegen rules
 ##

--- a/adapter/config/memory/BUILD
+++ b/adapter/config/memory/BUILD
@@ -15,5 +15,8 @@ go_test(
     size = "small",
     srcs = ["config_test.go"],
     library = ":go_default_library",
-    deps = ["//test/mock:go_default_library"],
+    deps = [
+        "//model:go_default_library",
+        "//test/mock:go_default_library",
+    ],
 )

--- a/adapter/config/memory/config_test.go
+++ b/adapter/config/memory/config_test.go
@@ -17,10 +17,16 @@ package memory
 import (
 	"testing"
 
+	"istio.io/pilot/model"
 	"istio.io/pilot/test/mock"
 )
 
 func TestStoreInvariant(t *testing.T) {
 	store := Make(mock.Types)
 	mock.CheckMapInvariant(store, t, 10)
+}
+
+func TestIstioConfig(t *testing.T) {
+	store := Make(model.IstioConfigTypes)
+	mock.CheckIstioConfigTypes(store, t)
 }

--- a/adapter/config/tpr/controller_test.go
+++ b/adapter/config/tpr/controller_test.go
@@ -313,7 +313,7 @@ func createIngress(ingress *v1beta1.Ingress, client kubernetes.Interface, t *tes
 	}
 }
 
-func TestIstioConfig(t *testing.T) {
+func TestIstioConfigTODO(t *testing.T) {
 	client, err := kube.CreateInterface(kubeconfig(t))
 	if err != nil {
 		t.Fatal(err)

--- a/adapter/config/tpr/controller_test.go
+++ b/adapter/config/tpr/controller_test.go
@@ -15,7 +15,6 @@
 package tpr
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -33,21 +32,12 @@ import (
 )
 
 func TestIngressController(t *testing.T) {
-	client, err := kube.CreateInterface(kubeconfig(t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ns, err := util.CreateNamespace(client)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	defer util.DeleteNamespace(client, ns)
-	cl := makeClient(ns, t)
-	t.Parallel()
+	cl, cleanup := makeTempClient(t)
+	defer cleanup()
 
 	mesh := proxy.DefaultMeshConfig()
 	ctl := NewController(cl, &mesh, kube.ControllerOptions{
-		Namespace:    ns,
+		Namespace:    cl.namespace,
 		ResyncPeriod: resync,
 	})
 
@@ -67,7 +57,7 @@ func TestIngressController(t *testing.T) {
 	nginxIngress := v1beta1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "nginx-ingress",
-			Namespace: ns,
+			Namespace: cl.namespace,
 			Annotations: map[string]string{
 				kube.IngressClassAnnotation: "nginx",
 			},
@@ -86,7 +76,7 @@ func TestIngressController(t *testing.T) {
 	ingress := v1beta1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "test-ingress",
-			Namespace: ns,
+			Namespace: cl.namespace,
 			Annotations: map[string]string{
 				kube.IngressClassAnnotation: mesh.IngressClass,
 			},
@@ -161,7 +151,7 @@ func TestIngressController(t *testing.T) {
 	}, t)
 	rules, err := ctl.List(model.IngressRule)
 	if err != nil {
-		t.Errorf("ctl.List(model.IngressRule, %s) => error: %v", ns, err)
+		t.Errorf("ctl.List(model.IngressRule, %s) => error: %v", cl.namespace, err)
 	}
 	if len(rules) != expectedRuleCount {
 		t.Errorf("expected %d IngressRule objects to be created, found %d", expectedRuleCount, len(rules))
@@ -188,17 +178,8 @@ func TestIngressController(t *testing.T) {
 }
 
 func TestIngressClass(t *testing.T) {
-	client, err := kube.CreateInterface(kubeconfig(t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ns, err := util.CreateNamespace(client)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	defer util.DeleteNamespace(client, ns)
-	cl := makeClient(ns, t)
-	t.Parallel()
+	cl, cleanup := makeTempClient(t)
+	defer cleanup()
 
 	cases := []struct {
 		ingressMode   proxyconfig.ProxyMeshConfig_IngressControllerMode
@@ -231,7 +212,7 @@ func TestIngressClass(t *testing.T) {
 		mesh := proxy.DefaultMeshConfig()
 		mesh.IngressControllerMode = c.ingressMode
 		ctl := NewController(cl, &mesh, kube.ControllerOptions{
-			Namespace:    ns,
+			Namespace:    cl.namespace,
 			ResyncPeriod: resync,
 		})
 
@@ -247,59 +228,26 @@ func TestIngressClass(t *testing.T) {
 }
 
 func TestController(t *testing.T) {
-	client, err := kube.CreateInterface(kubeconfig(t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ns, err := util.CreateNamespace(client)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	defer util.DeleteNamespace(client, ns)
-	cl := makeClient(ns, t)
-	t.Parallel()
-
+	cl, cleanup := makeTempClient(t)
+	defer cleanup()
 	mesh := proxy.DefaultMeshConfig()
-	ctl := NewController(cl, &mesh, kube.ControllerOptions{Namespace: ns, ResyncPeriod: resync})
-
+	ctl := NewController(cl, &mesh, kube.ControllerOptions{Namespace: cl.namespace, ResyncPeriod: resync})
 	mock.CheckCacheEvents(cl, ctl, 5, t)
 }
 
 func TestControllerCacheFreshness(t *testing.T) {
-	client, err := kube.CreateInterface(kubeconfig(t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ns, err := util.CreateNamespace(client)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	defer util.DeleteNamespace(client, ns)
-	cl := makeClient(ns, t)
-	t.Parallel()
-
+	cl, cleanup := makeTempClient(t)
+	defer cleanup()
 	mesh := proxy.DefaultMeshConfig()
-	ctl := NewController(cl, &mesh, kube.ControllerOptions{Namespace: ns, ResyncPeriod: resync})
-
+	ctl := NewController(cl, &mesh, kube.ControllerOptions{Namespace: cl.namespace, ResyncPeriod: resync})
 	mock.CheckCacheFreshness(ctl, t)
 }
 
 func TestControllerClientSync(t *testing.T) {
-	client, err := kube.CreateInterface(kubeconfig(t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ns, err := util.CreateNamespace(client)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	defer util.DeleteNamespace(client, ns)
-	cl := makeClient(ns, t)
-	t.Parallel()
-
+	cl, cleanup := makeTempClient(t)
+	defer cleanup()
 	mesh := proxy.DefaultMeshConfig()
-	ctl := NewController(cl, &mesh, kube.ControllerOptions{Namespace: ns, ResyncPeriod: resync})
-
+	ctl := NewController(cl, &mesh, kube.ControllerOptions{Namespace: cl.namespace, ResyncPeriod: resync})
 	mock.CheckCacheSync(cl, ctl, 5, t)
 }
 
@@ -310,59 +258,5 @@ const (
 func createIngress(ingress *v1beta1.Ingress, client kubernetes.Interface, t *testing.T) {
 	if _, err := client.ExtensionsV1beta1().Ingresses(ingress.Namespace).Create(ingress); err != nil {
 		t.Errorf("Cannot create ingress in namespace %s (error: %v)", ingress.Namespace, err)
-	}
-}
-
-func TestIstioConfigTODO(t *testing.T) {
-	client, err := kube.CreateInterface(kubeconfig(t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ns, err := util.CreateNamespace(client)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	defer util.DeleteNamespace(client, ns)
-	cl := makeClient(ns, t)
-	t.Parallel()
-
-	rule := &proxyconfig.RouteRule{
-		Destination: "foo",
-		Name:        "test",
-		Match: &proxyconfig.MatchCondition{
-			HttpHeaders: map[string]*proxyconfig.StringMatch{
-				"uri": {
-					MatchType: &proxyconfig.StringMatch_Exact{
-						Exact: "test",
-					},
-				},
-			},
-		},
-	}
-
-	if _, err := cl.Post(rule); err != nil {
-		t.Errorf("cl.Post() => error %v, want no error", err)
-	}
-
-	out, exists, _ := cl.Get(model.RouteRule, rule.Name)
-	if !exists {
-		t.Errorf("cl.Get() => missing")
-		return
-	}
-
-	if !reflect.DeepEqual(rule, out) {
-		t.Errorf("cl.Get(%v) => %v, want %v", rule.Name, out, rule)
-	}
-
-	registry := model.MakeIstioStore(cl)
-
-	rules := registry.RouteRules()
-	if len(rules) != 1 || !reflect.DeepEqual(rules[rule.Name], rule) {
-		t.Errorf("RouteRules() => %v, want %v", rules, rule)
-	}
-
-	destinations := registry.DestinationPolicies()
-	if len(destinations) > 0 {
-		t.Errorf("DestinationPolicies() => %v, want empty", destinations)
 	}
 }

--- a/adapter/config/tpr/conversion.go
+++ b/adapter/config/tpr/conversion.go
@@ -33,7 +33,16 @@ import (
 
 // configKey assigns k8s TPR name to Istio config
 func configKey(typ, key string) string {
-	return typ + "-" + key
+	switch typ {
+	case model.RouteRule, model.IngressRule:
+		return typ + "-" + key
+	case model.DestinationPolicy:
+		// TODO: special key encoding for long hostnames-based keys
+		parts := strings.Split(key, ".")
+		return typ + "-" + strings.Replace(parts[0], "-", "--", -1) +
+			"-" + strings.Replace(parts[1], "-", "--", -1)
+	}
+	return key
 }
 
 // modelToKube translates Istio config to k8s config JSON
@@ -66,7 +75,7 @@ func (cl *Client) convertConfig(item *Config) (model.Config, error) {
 			}
 			return model.Config{
 				Type:     schema.Type,
-				Key:      strings.TrimPrefix(item.Metadata.Name, schema.Type+"-"),
+				Key:      schema.Key(data),
 				Revision: item.Metadata.ResourceVersion,
 				Content:  data,
 			}, nil

--- a/adapter/config/tpr/conversion.go
+++ b/adapter/config/tpr/conversion.go
@@ -109,7 +109,6 @@ func convertIngress(ingress v1beta1.Ingress, domainSuffix string) map[string]pro
 	messages := make(map[string]proto.Message)
 
 	keyOf := func(ruleNum, pathNum int) string {
-		// TODO: namespace
 		return encodeIngressRuleName(ingress.Name, ingress.Namespace, ruleNum, pathNum)
 	}
 

--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -56,8 +56,3 @@ echo buildGitRevision   "${BUILD_GIT_REVISION}"
 echo buildGitBranch     "${BRANCH}"
 echo buildUser          "$(whoami)"
 echo buildHost          "$(hostname -f)"
-
-# Add kube-inject hub and tag key-values if present
-if [ -a ${ROOT}/kube-inject-versions ]; then
-    source ${ROOT}/kube-inject-versions
-fi

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -21,12 +21,11 @@ for f in dest_policy.pb.go  http_fault.pb.go  l4_fault.pb.go  proxy_mesh.pb.go  
   ln -sf $(pwd)/bazel-genfiles/external/io_istio_api/proxy/v1/config/$f \
     vendor/istio.io/api/proxy/v1/config/
 done
+
 mkdir -p vendor/istio.io/pilot/test/grpcecho
-ln -sf $(pwd)/bazel-genfiles/test/grpcecho/*.pb.go \
-   vendor/istio.io/pilot/test/grpcecho/
-mkdir -p vendor/github.com/googleapis/googleapis/google/rpc
-ln -sf $(pwd)/bazel-genfiles/external/com_github_googleapis_googleapis/google/rpc/*.pb.go \
-   vendor/github.com/googleapis/googleapis/google/rpc/
+for f in $(pwd)/bazel-genfiles/test/grpcecho/*.pb.go; do
+  ln -sf $f vendor/istio.io/pilot/test/grpcecho/
+done
 
 # Link mock gen files
 ln -sf "$(pwd)/bazel-genfiles/model/mock_config_gen_test.go" \

--- a/codecov.requirement
+++ b/codecov.requirement
@@ -1,4 +1,3 @@
-istio.io/pilot/cmd/istioctl	60
 istio.io/pilot/model	80
 istio.io/pilot/platform/kube	50
 istio.io/pilot/proxy/envoy	50

--- a/kube-inject-versions
+++ b/kube-inject-versions
@@ -1,7 +1,0 @@
-# Output image version for kube-inject in the form of key-value pairs
-# for consumption by bazel's linkstamp. See
-# github.com/bazelbuild/bazel/blob/master/tools/buildstamp/ for
-# details on the expected format and usage.
-
-echo KubeInjectHub docker.io/istio
-echo KubeInjectTag 0.1

--- a/model/BUILD
+++ b/model/BUILD
@@ -47,6 +47,7 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
+        "//test/mock:go_default_library",
         "@com_github_davecgh_go_spew//spew:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/model/config.go
+++ b/model/config.go
@@ -245,26 +245,32 @@ var (
 		},
 	}
 
+	// IngressRuleDescriptor describes ingress rules
+	IngressRuleDescriptor = ProtoSchema{
+		Type:        IngressRule,
+		MessageName: IngressRuleProto,
+		Validate:    ValidateIngressRule,
+		Key: func(config proto.Message) string {
+			rule := config.(*proxyconfig.IngressRule)
+			return fmt.Sprintf("%s", rule.Name)
+		},
+	}
+
+	// DestinationPolicyDescriptor describes destination rules
+	DestinationPolicyDescriptor = ProtoSchema{
+		Type:        DestinationPolicy,
+		MessageName: DestinationPolicyProto,
+		Validate:    ValidateDestinationPolicy,
+		Key: func(config proto.Message) string {
+			return config.(*proxyconfig.DestinationPolicy).Destination
+		},
+	}
+
 	// IstioConfigTypes lists all Istio config types with schemas and validation
 	IstioConfigTypes = ConfigDescriptor{
 		RouteRuleDescriptor,
-		ProtoSchema{
-			Type:        IngressRule,
-			MessageName: IngressRuleProto,
-			Validate:    ValidateIngressRule,
-			Key: func(config proto.Message) string {
-				rule := config.(*proxyconfig.IngressRule)
-				return fmt.Sprintf("%s", rule.Name)
-			},
-		},
-		ProtoSchema{
-			Type:        DestinationPolicy,
-			MessageName: DestinationPolicyProto,
-			Validate:    ValidateDestinationPolicy,
-			Key: func(config proto.Message) string {
-				return config.(*proxyconfig.DestinationPolicy).Destination
-			},
-		},
+		IngressRuleDescriptor,
+		DestinationPolicyDescriptor,
 	}
 )
 

--- a/model/config.go
+++ b/model/config.go
@@ -234,17 +234,20 @@ const (
 )
 
 var (
+	// RouteRuleDescriptor describes route rules
+	RouteRuleDescriptor = ProtoSchema{
+		Type:        RouteRule,
+		MessageName: RouteRuleProto,
+		Validate:    ValidateRouteRule,
+		Key: func(config proto.Message) string {
+			rule := config.(*proxyconfig.RouteRule)
+			return fmt.Sprintf("%s", rule.Name)
+		},
+	}
+
 	// IstioConfigTypes lists all Istio config types with schemas and validation
 	IstioConfigTypes = ConfigDescriptor{
-		ProtoSchema{
-			Type:        RouteRule,
-			MessageName: RouteRuleProto,
-			Validate:    ValidateRouteRule,
-			Key: func(config proto.Message) string {
-				rule := config.(*proxyconfig.RouteRule)
-				return fmt.Sprintf("%s", rule.Name)
-			},
-		},
+		RouteRuleDescriptor,
 		ProtoSchema{
 			Type:        IngressRule,
 			MessageName: IngressRuleProto,

--- a/model/config.go
+++ b/model/config.go
@@ -367,13 +367,11 @@ func (i *istioConfigStore) DestinationPolicies() []*proxyconfig.DestinationPolic
 }
 
 func (i *istioConfigStore) DestinationPolicy(destination string, tags Tags) *proxyconfig.DestinationVersionPolicy {
-	// TODO: optimize destination policy retrieval
-	for _, value := range i.DestinationPolicies() {
-		if value.Destination == destination {
-			for _, policy := range value.Policy {
-				if tags.Equals(policy.Tags) {
-					return policy
-				}
+	value, exists, _ := i.Get(DestinationPolicy, destination)
+	if exists {
+		for _, policy := range value.(*proxyconfig.DestinationPolicy).Policy {
+			if tags.Equals(policy.Tags) {
+				return policy
 			}
 		}
 	}

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -158,7 +158,6 @@ var (
 
 	dstTags0 = map[string]string{"a": "b"}
 	dstTags1 = map[string]string{"c": "d"}
-	dstTags2 = map[string]string{"e": "f"}
 
 	dstPolicy1 = &proxyconfig.DestinationPolicy{
 		Destination: "foo",
@@ -170,10 +169,6 @@ var (
 	dstPolicy3 = &proxyconfig.DestinationPolicy{
 		Destination: "bar",
 		Policy:      []*proxyconfig.DestinationVersionPolicy{{Tags: dstTags1}},
-	}
-	dstPolicy4 = &proxyconfig.DestinationPolicy{
-		Destination: "baz",
-		Policy:      []*proxyconfig.DestinationVersionPolicy{{Tags: dstTags2}},
 	}
 )
 

--- a/model/validation.go
+++ b/model/validation.go
@@ -649,6 +649,9 @@ func ValidateRouteRule(msg proto.Message) error {
 	if value.Name == "" {
 		errs = multierror.Append(errs, fmt.Errorf("route rule must have a name"))
 	}
+	if !IsDNS1123Label(value.Name) {
+		errs = multierror.Append(errs, fmt.Errorf("route rule name must be a host name label"))
+	}
 	if value.Destination == "" {
 		errs = multierror.Append(errs, fmt.Errorf("route rule must have a destination service"))
 	}
@@ -737,6 +740,9 @@ func ValidateIngressRule(msg proto.Message) error {
 	var errs error
 	if value.Name == "" {
 		errs = multierror.Append(errs, fmt.Errorf("ingress rule must have a name"))
+	}
+	if !IsDNS1123Label(value.Name) {
+		errs = multierror.Append(errs, fmt.Errorf("ingress rule name must be a host name label"))
 	}
 	if value.Destination == "" {
 		errs = multierror.Append(errs, fmt.Errorf("ingress rule must have a destination service"))

--- a/model/validation.go
+++ b/model/validation.go
@@ -72,16 +72,27 @@ func ValidatePort(port int) error {
 // Validate checks that each name conforms to the spec and has a ProtoMessage
 func (descriptor ConfigDescriptor) Validate() error {
 	var errs error
+	types := make(map[string]bool)
+	messages := make(map[string]bool)
+
 	for _, v := range descriptor {
 		if v.Key == nil {
-			errs = multierror.Append(errs, fmt.Errorf("missing key function for type: %q", v.Type))
+			errs = multierror.Append(errs, fmt.Errorf("missing the required key function for type: %q", v.Type))
 		}
 		if !IsDNS1123Label(v.Type) {
 			errs = multierror.Append(errs, fmt.Errorf("invalid type: %q", v.Type))
 		}
 		if proto.MessageType(v.MessageName) == nil {
-			errs = multierror.Append(errs, fmt.Errorf("cannot find proto message type: %q", v.MessageName))
+			errs = multierror.Append(errs, fmt.Errorf("cannot discover proto message type: %q", v.MessageName))
 		}
+		if _, exists := types[v.Type]; exists {
+			errs = multierror.Append(errs, fmt.Errorf("duplicate type: %q", v.Type))
+		}
+		types[v.Type] = true
+		if _, exists := messages[v.MessageName]; exists {
+			errs = multierror.Append(errs, fmt.Errorf("duplicate message type: %q", v.MessageName))
+		}
+		messages[v.MessageName] = true
 	}
 	return errs
 }

--- a/test/mock/BUILD
+++ b/test/mock/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//test/util:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@io_istio_api//:go_default_library",
     ],
 )
 

--- a/test/mock/config.go
+++ b/test/mock/config.go
@@ -29,28 +29,29 @@ import (
 	"istio.io/pilot/test/util"
 )
 
-// Mock config type
 const (
+	// Type is the mock config type
 	Type = "mock-config"
 )
 
-// Mock config descriptor
 var (
-	Types = model.ConfigDescriptor{
-		model.ProtoSchema{
-			Type:        Type,
-			MessageName: "mock.MockConfig",
-			Validate: func(config proto.Message) error {
-				if config.(*MockConfig).Key == "" {
-					return errors.New("empty key")
-				}
-				return nil
-			},
-			Key: func(config proto.Message) string {
-				return config.(*MockConfig).Key
-			},
+	// Descriptor for the mock config
+	Descriptor = model.ProtoSchema{
+		Type:        Type,
+		MessageName: "mock.MockConfig",
+		Validate: func(config proto.Message) error {
+			if config.(*MockConfig).Key == "" {
+				return errors.New("empty key")
+			}
+			return nil
+		},
+		Key: func(config proto.Message) string {
+			return config.(*MockConfig).Key
 		},
 	}
+
+	// Types defines the mock config descriptor
+	Types = model.ConfigDescriptor{Descriptor}
 )
 
 // Make creates a mock config indexed by a number

--- a/test/mock/config.go
+++ b/test/mock/config.go
@@ -226,13 +226,19 @@ func CheckMapInvariant(r model.ConfigStore, t *testing.T, n int) {
 // CheckIstioConfigTypes validates that an empty store can ingest Istio config objects
 func CheckIstioConfigTypes(store model.ConfigStore, t *testing.T) {
 	if _, err := store.Post(ExampleRouteRule); err != nil {
-		t.Error(err)
+		t.Errorf("Post(RouteRule) => got %v", err)
 	}
 	if _, err := store.Post(ExampleIngressRule); err != nil {
-		t.Error(err)
+		t.Errorf("Post(IngressRule) => got %v", err)
 	}
 	if _, err := store.Post(ExampleDestinationPolicy); err != nil {
-		t.Error(err)
+		t.Errorf("Post(DestinationPolicy) => got %v", err)
+	}
+
+	registry := model.MakeIstioStore(store)
+	rules := registry.RouteRules()
+	if len(rules) != 1 || !reflect.DeepEqual(rules[ExampleRouteRule.Name], ExampleRouteRule) {
+		t.Errorf("RouteRules() => %v, want %v", rules, ExampleRouteRule)
 	}
 }
 

--- a/tools/version/BUILD
+++ b/tools/version/BUILD
@@ -3,9 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["version.go"],
-    data = [
-        "//:kube-inject-versions",
-    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Also: fix minor defects:
- simplify redundant code to allocate test namespaces
- retrieve destination policy by key instead of iterating over objects

