### PR TITLE
Implement store aggregator

### DIFF
--- a/adapter/config/aggregate/BUILD
+++ b/adapter/config/aggregate/BUILD
@@ -15,6 +15,7 @@ go_test(
     srcs = ["config_test.go"],
     deps = [
         ":go_default_library",
+        "//adapter/config/memory:go_default_library",
         "//model:go_default_library",
         "//test/mock:go_default_library",
     ],

--- a/adapter/config/aggregate/config.go
+++ b/adapter/config/aggregate/config.go
@@ -1,0 +1,103 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package aggregate implements a type-aggregator for config stores.  The
+// aggregate config store multiplexes requests to a configuration store based
+// on the type of the configuration objects. The aggregate config store cache
+// performs the reverse, by aggregating events from the multiplexed stores and
+// dispatching them back to event handlers.
+package aggregate
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+
+	"istio.io/pilot/model"
+)
+
+// Make creates an aggregate config store from several config stores and
+// unifies their descriptors
+func Make(stores []model.ConfigStore) (model.ConfigStore, error) {
+	union := model.ConfigDescriptor{}
+	storeTypes := make(map[string]model.ConfigStore)
+	for _, store := range stores {
+		for _, descriptor := range store.ConfigDescriptor() {
+			union = append(union, descriptor)
+			storeTypes[descriptor.Type] = store
+		}
+	}
+	if err := union.Validate(); err != nil {
+		return nil, err
+	}
+	return &store{
+		descriptor: union,
+		stores:     storeTypes,
+	}, nil
+}
+
+type store struct {
+	// descriptor is the unified
+	descriptor model.ConfigDescriptor
+
+	// stores is a mapping from config type to a store
+	stores map[string]model.ConfigStore
+}
+
+func (cr *store) ConfigDescriptor() model.ConfigDescriptor {
+	return cr.descriptor
+}
+
+func (cr *store) Get(typ, key string) (proto.Message, bool, string) {
+	store, exists := cr.stores[typ]
+	if !exists {
+		return nil, false, ""
+	}
+	return store.Get(typ, key)
+}
+
+func (cr *store) List(typ string) ([]model.Config, error) {
+	store, exists := cr.stores[typ]
+	if !exists {
+		return nil, nil
+	}
+	return store.List(typ)
+}
+
+func (cr *store) Delete(typ, key string) error {
+	store, exists := cr.stores[typ]
+	if !exists {
+		return fmt.Errorf("missing type %q", typ)
+	}
+	return store.Delete(typ, key)
+}
+
+func (cr *store) Post(config proto.Message) (string, error) {
+	schema, exists := cr.descriptor.GetByMessageName(proto.MessageName(config))
+	if !exists {
+		return "", errors.New("missing type")
+	}
+	store := cr.stores[schema.Type]
+	return store.Post(config)
+}
+
+func (cr *store) Put(config proto.Message, oldRevision string) (string, error) {
+	schema, exists := cr.descriptor.GetByMessageName(proto.MessageName(config))
+	if !exists {
+		return "", errors.New("missing type")
+	}
+	store := cr.stores[schema.Type]
+	return store.Put(config, oldRevision)
+}

--- a/adapter/config/aggregate/config_test.go
+++ b/adapter/config/aggregate/config_test.go
@@ -31,8 +31,11 @@ func TestStoreInvariant(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 	mock.CheckMapInvariant(store, t, 10)
+}
 
-	if _, err = aggregate.Make([]model.ConfigStore{mockStore, mockStore}); err == nil {
+func TestStoreValidation(t *testing.T) {
+	mockStore := memory.Make(mock.Types)
+	if _, err := aggregate.Make([]model.ConfigStore{mockStore, mockStore}); err == nil {
 		t.Error("expected error in duplicate types in the config store")
 	}
 }

--- a/adapter/config/aggregate/config_test.go
+++ b/adapter/config/aggregate/config_test.go
@@ -12,22 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memory_test
+package aggregate_test
 
 import (
 	"testing"
 
+	"istio.io/pilot/adapter/config/aggregate"
 	"istio.io/pilot/adapter/config/memory"
 	"istio.io/pilot/model"
 	"istio.io/pilot/test/mock"
 )
 
 func TestStoreInvariant(t *testing.T) {
-	store := memory.Make(mock.Types)
+	mockStore := memory.Make(mock.Types)
+	istioStore := memory.Make(model.IstioConfigTypes)
+	store, err := aggregate.Make([]model.ConfigStore{mockStore, istioStore})
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
 	mock.CheckMapInvariant(store, t, 10)
-}
 
-func TestIstioConfig(t *testing.T) {
-	store := Make(model.IstioConfigTypes)
-	mock.CheckIstioConfigTypes(store, t)
+	if _, err = aggregate.Make([]model.ConfigStore{mockStore, mockStore}); err == nil {
+		t.Error("expected error in duplicate types in the config store")
+	}
 }

--- a/adapter/config/memory/config_test.go
+++ b/adapter/config/memory/config_test.go
@@ -28,6 +28,6 @@ func TestStoreInvariant(t *testing.T) {
 }
 
 func TestIstioConfig(t *testing.T) {
-	store := Make(model.IstioConfigTypes)
+	store := memory.Make(model.IstioConfigTypes)
 	mock.CheckIstioConfigTypes(store, t)
 }

--- a/model/BUILD
+++ b/model/BUILD
@@ -47,7 +47,6 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
-        "//test/mock:go_default_library",
         "@com_github_davecgh_go_spew//spew:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",


### PR DESCRIPTION
A subsequent PR will add:
- in-memory cache controller (implementation of `ConfigStoreCache`)
- separate ingress bits from TPR and aggregate over the two stores in the main config store