### PR TITLE
Filter ingress ports

### DIFF
--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -276,6 +276,9 @@ func buildIngressRoute(ingress *proxyconfig.IngressRule,
 	if err != nil {
 		return nil, "", err
 	}
+	if servicePort.Protocol != model.ProtocolHTTP {
+		return nil, "", fmt.Errorf("unsupported protocol %q for %q", servicePort.Protocol, service.Hostname)
+	}
 
 	// unfold the rules for the destination port
 	routes := buildDestinationHTTPRoutes(service, servicePort, rules)

--- a/proxy/envoy/resolve.go
+++ b/proxy/envoy/resolve.go
@@ -10,13 +10,13 @@ import (
 	"github.com/golang/glog"
 )
 
-func resolveStatsdAddr(statsdAdrr string) (string, error) {
-	if statsdAdrr == "" {
+func resolveStatsdAddr(statsdAddr string) (string, error) {
+	if statsdAddr == "" {
 		return "", nil
 	}
-	colon := strings.Index(statsdAdrr, ":")
-	host := statsdAdrr[:colon]
-	port := statsdAdrr[colon:]
+	colon := strings.Index(statsdAddr, ":")
+	host := statsdAddr[:colon]
+	port := statsdAddr[colon:]
 	glog.Infof("Attempting to lookup statsd address: %s", host)
 	defer glog.Infof("Finished lookup of statsd address: %s", host)
 	// lookup the statsd udp address with a timeout of 15 seconds.


### PR DESCRIPTION
Filter out non-HTTP ingress ports. This should fix the Envoy crashing observed in https://github.com/istio/issues/issues/20. Instead, Pilot will log a warning.