### PR TITLE
added priviledged=true to the init container and to all tests

### DIFF
--- a/platform/kube/inject/inject.go
+++ b/platform/kube/inject/inject.go
@@ -130,8 +130,8 @@ func injectIntoPodTemplateSpec(p *Params, t *v1.PodTemplateSpec) error {
 		"securityContext": map[string]interface{}{
 			"capabilities": map[string]interface{}{
 				"add":        []string{"NET_ADMIN"},
-				"privileged": true,
 			},
+		  "privileged": true,
 		},
 	})
 

--- a/platform/kube/inject/inject.go
+++ b/platform/kube/inject/inject.go
@@ -129,7 +129,8 @@ func injectIntoPodTemplateSpec(p *Params, t *v1.PodTemplateSpec) error {
 		"imagePullPolicy": "Always",
 		"securityContext": map[string]interface{}{
 			"capabilities": map[string]interface{}{
-				"add": []string{"NET_ADMIN"},
+				"add":        []string{"NET_ADMIN"},
+				"privileged": true,
 			},
 		},
 	})

--- a/platform/kube/inject/inject.go
+++ b/platform/kube/inject/inject.go
@@ -129,9 +129,9 @@ func injectIntoPodTemplateSpec(p *Params, t *v1.PodTemplateSpec) error {
 		"imagePullPolicy": "Always",
 		"securityContext": map[string]interface{}{
 			"capabilities": map[string]interface{}{
-				"add":        []string{"NET_ADMIN"},
+				"add": []string{"NET_ADMIN"},
 			},
-		  "privileged": true,
+			"privileged": true,
 		},
 	})
 

--- a/platform/kube/inject/testdata/auth.cert-dir.yaml.injected
+++ b/platform/kube/inject/testdata/auth.cert-dir.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged::true"}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/auth.cert-dir.yaml.injected
+++ b/platform/kube/inject/testdata/auth.cert-dir.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged::true"}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/platform/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/platform/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/platform/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/auth.yaml.injected
+++ b/platform/kube/inject/testdata/auth.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/auth.yaml.injected
+++ b/platform/kube/inject/testdata/auth.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/auth.yaml.injected
+++ b/platform/kube/inject/testdata/auth.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/platform/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}},{"args":["-c","sysctl
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}},{"args":["-c","sysctl
           -w kernel.core_pattern=/tmp/core.%e.%p.%t \u0026\u0026 ulimit -c unlimited"],"command":["/bin/sh"],"image":"alpine","imagePullPolicy":"Always","name":"enable-core-dump","securityContext":{"privileged":true}}]'
       creationTimestamp: null
       labels:

--- a/platform/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/platform/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}},{"args":["-c","sysctl
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}},{"args":["-c","sysctl
           -w kernel.core_pattern=/tmp/core.%e.%p.%t \u0026\u0026 ulimit -c unlimited"],"command":["/bin/sh"],"image":"alpine","imagePullPolicy":"Always","name":"enable-core-dump","securityContext":{"privileged":true}}]'
       creationTimestamp: null
       labels:

--- a/platform/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/platform/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}},{"args":["-c","sysctl
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}},{"args":["-c","sysctl
           -w kernel.core_pattern=/tmp/core.%e.%p.%t \u0026\u0026 ulimit -c unlimited"],"command":["/bin/sh"],"image":"alpine","imagePullPolicy":"Always","name":"enable-core-dump","securityContext":{"privileged":true}}]'
       creationTimestamp: null
       labels:

--- a/platform/kube/inject/testdata/frontend.yaml.injected
+++ b/platform/kube/inject/testdata/frontend.yaml.injected
@@ -25,7 +25,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/frontend.yaml.injected
+++ b/platform/kube/inject/testdata/frontend.yaml.injected
@@ -25,7 +25,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/frontend.yaml.injected
+++ b/platform/kube/inject/testdata/frontend.yaml.injected
@@ -25,7 +25,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/platform/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/platform/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/platform/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-multi.yaml.injected
+++ b/platform/kube/inject/testdata/hello-multi.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-multi.yaml.injected
+++ b/platform/kube/inject/testdata/hello-multi.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello
@@ -65,7 +65,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-multi.yaml.injected
+++ b/platform/kube/inject/testdata/hello-multi.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-probes.yaml.injected
+++ b/platform/kube/inject/testdata/hello-probes.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-probes.yaml.injected
+++ b/platform/kube/inject/testdata/hello-probes.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-probes.yaml.injected
+++ b/platform/kube/inject/testdata/hello-probes.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello.yaml.injected
+++ b/platform/kube/inject/testdata/hello.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello.yaml.injected
+++ b/platform/kube/inject/testdata/hello.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello.yaml.injected
+++ b/platform/kube/inject/testdata/hello.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"], "priviledged":true}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}, "privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/multi-init.yaml.injected
+++ b/platform/kube/inject/testdata/multi-init.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"command":["sh","-c","true"],"image":"busybox","name":"init-one"},{"command":["sh","-c","true"],"image":"busybox","name":"init-two"},{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"command":["sh","-c","true"],"image":"busybox","name":"init-one"},{"command":["sh","-c","true"],"image":"busybox","name":"init-two"},{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"],"priviledged":true}}}]'
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/multi-init.yaml.injected
+++ b/platform/kube/inject/testdata/multi-init.yaml.injected
@@ -11,7 +11,7 @@ spec:
       annotations:
         alpha.istio.io/sidecar: injected
         alpha.istio.io/version: "12345678"
-        pod.beta.kubernetes.io/init-containers: '[{"command":["sh","-c","true"],"image":"busybox","name":"init-one"},{"command":["sh","-c","true"],"image":"busybox","name":"init-two"},{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"],"priviledged":true}}}]'
+        pod.beta.kubernetes.io/init-containers: '[{"command":["sh","-c","true"],"image":"busybox","name":"init-one"},{"command":["sh","-c","true"],"image":"busybox","name":"init-two"},{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}}]'
       creationTimestamp: null
       labels:
         app: hello


### PR DESCRIPTION
Commit https://github.com/istio/pilot/pull/921 on behalf of @bjartek.   

Add `privileged=true` to init-containers to unblock deployments with SELINUX (e.g. OpenShift). As @bjartek suggested in his original PR, this is functionally sufficient, but longer term someone needs to sort through what exact permissions are needed with SELinux and add the necessary RBAC rules to OpenShift similar to what what it is for Kubernetes in the main repo.

Fixes istio/issues#34