### PR TITLE
Publish coverage at postsubmit as well

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,8 @@ def postsubmit(gitUtils, bazel, utils) {
       sh('bin/install-prereqs.sh')
       bazel.test('//...')
       sh('bin/init.sh')
-      sh('bin/codecov.sh')
+      sh('bin/codecov.sh | tee codecov.report')
+      sh('bin/toolbox/presubmit/pkg_coverage.sh')
       utils.publishCodeCoverage('PILOT_CODECOV_TOKEN')
     }
     utils.fastForwardStable('pilot')


### PR DESCRIPTION
As we did before at presubmit, now we want like to collect data from postsubmit. Theoretically, they should be the same, but we would like to figure it out. And if so, we will only keep one of them.