### PR TITLE
Enabling back windows istioctl build for postsubmit only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ def postsubmit(gitUtils, bazel, utils) {
     }
     stage('Build istioctl') {
       def remotePath = gitUtils.artifactsPath('istioctl')
-      sh("bin/upload-istioctl -p ${remotePath}")
+      sh("bin/upload-istioctl -r -p ${remotePath}")
     }
     stage('Integration Tests') {
       timeout(60) {
@@ -118,7 +118,7 @@ def release(gitUtils, bazel) {
     sh('touch platform/kube/config')
     stage('Build istioctl') {
       def remotePath = gitUtils.artifactsPath('istioctl')
-      sh("bin/upload-istioctl -p ${remotePath}")
+      sh("bin/upload-istioctl -r -p ${remotePath}")
     }
     stage('Docker Push') {
       def tags = "${env.GIT_SHORT_SHA},${env.ISTIO_VERSION}-${env.GIT_SHORT_SHA}"

--- a/bin/upload-istioctl
+++ b/bin/upload-istioctl
@@ -53,6 +53,6 @@ if [[ ${RELEASE} == true ]]; then
   mv istioctl.exe "${BIN_DIR}/istioctl-win.exe"
 fi
 if [[ -n "${BUCKET_PATH}" ]]; then
-  gsutil -m cp -r "${BIN_DIR}"/istioctl-* "${BUCKET_PATH}" \
+  gsutil -m cp -r "${BIN_DIR}"/istioctl-* "${BUCKET_PATH}/" \
     || { echo "Failed to upload binaries to ${BUCKET_PATH}"; exit 1; }
 fi

--- a/bin/upload-istioctl
+++ b/bin/upload-istioctl
@@ -49,7 +49,6 @@ if [[ ${RELEASE} == true ]]; then
   GOOS=darwin GOARCH=amd64 ${go} build -ldflags "${LDFLAGS}" istio.io/pilot/cmd/istioctl
   mv istioctl "${BIN_DIR}/istioctl-osx"
 
-  # install missing spf13/cobra dependency (windows only)
   GOOS=windows GOARCH=amd64 ${go} build -ldflags "${LDFLAGS}" istio.io/pilot/cmd/istioctl
   mv istioctl.exe "${BIN_DIR}/istioctl-win.exe"
 fi

--- a/bin/upload-istioctl
+++ b/bin/upload-istioctl
@@ -11,17 +11,19 @@ set -o pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN_DIR='.'
 BUCKET_PATH=''
+RELEASE=false
 
 function cleanup {
   rm -rf "${BIN_DIR}"
 }
 
-while getopts :p: arg; do
+while getopts :p:r arg; do
   case ${arg} in
     p)
       BUCKET_PATH="${OPTARG}"
       BIN_DIR="$(mktemp -d /tmp/istioctl.XXXX)"
       ;;
+    r) RELEASE=true;;
     *) error_exit "Unrecognized argument -${OPTARG}";;
   esac
 done
@@ -31,21 +33,23 @@ done
 bin/init.sh
 cp -f "${ROOT}/bazel-bin/cmd/istioctl/istioctl" "${BIN_DIR}/istioctl-linux"
 
-set linker flags for populating version info
-LDFLAGS=""
-while read line; do
-  read SYMBOL VALUE < <(echo $line)
-  LDFLAGS=${LDFLAGS}" -X istio.io/pilot/cmd/version.${SYMBOL}=${VALUE}"
-done < <(./bin/get_workspace_status)
 
-GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" istio.io/pilot/cmd/istioctl
-mv istioctl "${BIN_DIR}/istioctl-osx"
+if [[ ${RELEASE} == true ]]; then
+  # set linker flags for populating version info
+  LDFLAGS=""
+  while read line; do
+    read SYMBOL VALUE < <(echo $line)
+    LDFLAGS=${LDFLAGS}" -X istio.io/pilot/cmd/version.${SYMBOL}=${VALUE}"
+  done < <(./bin/get_workspace_status)
 
-# install missing spf13/cobra dependency (windows only)
-#go get github.com/inconshreveable/mousetrap
-#GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" istio.io/pilot/cmd/istioctl
-#mv istioctl.exe "${BIN_DIR}/istioctl-win.exe"
+  GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" istio.io/pilot/cmd/istioctl
+  mv istioctl "${BIN_DIR}/istioctl-osx"
 
+  # install missing spf13/cobra dependency (windows only)
+  go get github.com/inconshreveable/mousetrap
+  GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" istio.io/pilot/cmd/istioctl
+  mv istioctl.exe "${BIN_DIR}/istioctl-win.exe"
+fi
 if [[ -n "${BUCKET_PATH}" ]]; then
   gsutil -m cp -r "${BIN_DIR}"/istioctl-* "${BUCKET_PATH}" \
     || { echo "Failed to upload binaries to ${BUCKET_PATH}"; exit 1; }

--- a/bin/upload-istioctl
+++ b/bin/upload-istioctl
@@ -9,6 +9,7 @@ set -o nounset
 set -o pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIR_NAME="$(basename ${ROOT})"
 BIN_DIR='.'
 BUCKET_PATH=''
 RELEASE=false
@@ -35,6 +36,9 @@ cp -f "${ROOT}/bazel-bin/cmd/istioctl/istioctl" "${BIN_DIR}/istioctl-linux"
 
 
 if [[ ${RELEASE} == true ]]; then
+  export GOROOT="$(find ${ROOT}/bazel-${DIR_NAME}/external -type d -name 'go1_*')"
+  go=${GOROOT}/bin/go
+
   # set linker flags for populating version info
   LDFLAGS=""
   while read line; do
@@ -42,12 +46,11 @@ if [[ ${RELEASE} == true ]]; then
     LDFLAGS=${LDFLAGS}" -X istio.io/pilot/cmd/version.${SYMBOL}=${VALUE}"
   done < <(./bin/get_workspace_status)
 
-  GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" istio.io/pilot/cmd/istioctl
+  GOOS=darwin GOARCH=amd64 ${go} build -ldflags "${LDFLAGS}" istio.io/pilot/cmd/istioctl
   mv istioctl "${BIN_DIR}/istioctl-osx"
 
   # install missing spf13/cobra dependency (windows only)
-  go get github.com/inconshreveable/mousetrap
-  GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" istio.io/pilot/cmd/istioctl
+  GOOS=windows GOARCH=amd64 ${go} build -ldflags "${LDFLAGS}" istio.io/pilot/cmd/istioctl
   mv istioctl.exe "${BIN_DIR}/istioctl-win.exe"
 fi
 if [[ -n "${BUCKET_PATH}" ]]; then

--- a/prow/pilot-postsubmit.sh
+++ b/prow/pilot-postsubmit.sh
@@ -48,7 +48,7 @@ echo '=== Prerequisites ==='
 echo '=== Go Build ==='
 ./bin/init.sh
 
-echo q'=== Bazel Tests ==='
+echo '=== Bazel Tests ==='
 bazel test //...
 
 echo  '=== Code Coverage ==='
@@ -62,6 +62,9 @@ if [ "${CI:-}" == 'bootstrap' ]; then
 else
     echo 'Not in bootstrap environment, skipping code coverage publishing'
 fi
+
+echo '=== Build istioctl ==='
+./bin/upload-istioctl -r -p "gs://istio-artifacts/pilot/${GIT_SHA}/artifacts/istioctl"
 
 echo '=== Running e2e Tests ==='
 bin/e2e.sh -count 10 -logs=false -tag "${GIT_SHA}"

--- a/prow/pilot-presubmit.sh
+++ b/prow/pilot-presubmit.sh
@@ -46,8 +46,6 @@ echo '=== Bazel Build ==='
 ./bin/install-prereqs.sh
 bazel build //...
 
-echo '=== Build istioctl ==='
-./bin/upload-istioctl -p "gs://istio-artifacts/pilot/${GIT_SHA}/artifacts/istioctl"
 
 echo '=== Go Build ==='
 ./bin/init.sh
@@ -69,6 +67,9 @@ if [ "${CI:-}" == 'bootstrap' ]; then
 else
     echo 'Not in bootstrap environment, skipping code coverage publishing'
 fi
+
+echo '=== Build istioctl ==='
+./bin/upload-istioctl -p "gs://istio-artifacts/pilot/${GIT_SHA}/artifacts/istioctl"
 
 echo '=== Running e2e Tests ==='
 ./bin/e2e.sh -tag "${GIT_SHA}" -hub 'gcr.io/istio-testing'


### PR DESCRIPTION
- Simplifying Jenkins
- Enabling OSX and Windows istioctl builds for postsubmit and release artifacts 