### PR TITLE
Shouldn't have hardcoded 0.1 (or any 2 digit) tags

### DIFF
--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -44,7 +44,7 @@ fi
 
 RELEASE_TAG=$(git describe --match '[0-9]*\.[0-9]*\.[0-9]*' --exact-match 2> /dev/null || echo "")
 
-VERSION='unknown'
+VERSION="${BUILD_GIT_REVISION}"
 if [[ -n "${RELEASE_TAG}" ]]; then
   VERSION="${RELEASE_TAG}"
 elif [[ -n ${ISTIO_VERSION} ]]; then

--- a/cmd/istioctl/inject.go
+++ b/cmd/istioctl/inject.go
@@ -105,9 +105,6 @@ kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
 			if versionStr == "" {
 				versionStr = version.Line()
 			}
-			if tag == "" {
-				tag = versionStr
-			}
 
 			client, err := kube.CreateInterface(kubeconfig)
 			if err != nil {
@@ -140,7 +137,7 @@ func init() {
 	rootCmd.AddCommand(injectCmd)
 
 	injectCmd.PersistentFlags().StringVar(&hub, "hub", "docker.io/istio", "Docker hub")
-	injectCmd.PersistentFlags().StringVar(&tag, "tag", "", "Docker tag, defaults to same as version")
+	injectCmd.PersistentFlags().StringVar(&tag, "tag", version.Info.Version, "Docker tag")
 
 	injectCmd.PersistentFlags().StringVarP(&inFilename, "filename", "f",
 		"", "Input Kubernetes resource filename")

--- a/cmd/istioctl/inject.go
+++ b/cmd/istioctl/inject.go
@@ -105,6 +105,9 @@ kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
 			if versionStr == "" {
 				versionStr = version.Line()
 			}
+			if tag == "" {
+				tag = versionStr
+			}
 
 			client, err := kube.CreateInterface(kubeconfig)
 			if err != nil {
@@ -137,7 +140,7 @@ func init() {
 	rootCmd.AddCommand(injectCmd)
 
 	injectCmd.PersistentFlags().StringVar(&hub, "hub", "docker.io/istio", "Docker hub")
-	injectCmd.PersistentFlags().StringVar(&tag, "tag", "0.1", "Docker tag")
+	injectCmd.PersistentFlags().StringVar(&tag, "tag", "", "Docker tag, defaults to same as version")
 
 	injectCmd.PersistentFlags().StringVarP(&inFilename, "filename", "f",
 		"", "Input Kubernetes resource filename")


### PR DESCRIPTION
0.1.x releases have that dangerous setting of using 0.1 instead of 0.1.x for proxy and init images

fixing this (with the assumption that the correct -tag is passed for test/dev per @sebastienvas )