### PR TITLE
[WIP] Implement k8s sidecar initializer

### DIFF
--- a/bin/e2e.sh
+++ b/bin/e2e.sh
@@ -35,8 +35,8 @@ tag=$(whoami)_$(date +%y%m%d_%h%m%s)
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -tag) tag="$2"; shift ;;
-        -hub) hub="$2"; shift ;;
+        --tag|-tag) tag="$2"; shift ;;
+        --hub|-hub) hub="$2"; shift ;;
         *) args=$args" $1" ;;
     esac
     shift

--- a/bin/push-docker
+++ b/bin/push-docker
@@ -54,6 +54,7 @@ bazel build --output_groups=static //cmd/... //test/...
 \cp -f  "${bin}/test/server/server.static" docker/server
 \cp -f  "${bin}/cmd/pilot-agent/pilot-agent.static" docker/pilot-agent
 \cp -f  "${bin}/cmd/pilot-discovery/pilot-discovery.static" docker/pilot-discovery
+\cp -f  "${bin}/cmd/sidecar-initializer/sidecar-initializer.static" docker/sidecar-initializer
 
 # Build and push images
 
@@ -61,7 +62,7 @@ IFS=',' read -ra tags <<< "${tags}"
 IFS=',' read -ra hubs <<< "${hubs}"
 
 pushd docker
-  for image in app proxy proxy_init proxy_debug pilot; do
+  for image in app proxy proxy_init proxy_debug pilot sidecar_initializer; do
     local_image="${image}:${local_tag}"
     docker build -f "Dockerfile.${image}" -t "${local_image}" .
     for tag in ${tags[@]}; do

--- a/cmd/sidecar-initializer/BUILD
+++ b/cmd/sidecar-initializer/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//cmd:go_default_library",
+        "//platform/kube:go_default_library",
+        "//platform/kube/inject:go_default_library",
+        "//tools/version:go_default_library",
+        "@com_github_davecgh_go_spew//spew:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
+        "@com_github_hashicorp_go_multierror//:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "sidecar-initializer",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/cmd/sidecar-initializer/main.go
+++ b/cmd/sidecar-initializer/main.go
@@ -1,0 +1,102 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/api/core/v1"
+
+	"istio.io/pilot/cmd"
+	"istio.io/pilot/platform/kube"
+	"istio.io/pilot/platform/kube/inject"
+	"istio.io/pilot/tools/version"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/glog"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+)
+
+func getRootCmd() *cobra.Command {
+	flags := struct {
+		kubeconfig   string
+		meshconfig   string
+		hub          string
+		tag          string
+		namespace    string
+		resyncPeriod time.Duration
+	}{}
+
+	root := &cobra.Command{
+		Use:   "sidecar-initializer",
+		Short: "Kubernetes initializer for Istio sidecar",
+		RunE: func(*cobra.Command, []string) error {
+			client, err := kube.CreateInterface(flags.kubeconfig)
+			if err != nil {
+				return multierror.Prefix(err, "failed to connect to Kubernetes API.")
+			}
+
+			glog.V(2).Infof("version %s", version.Line())
+			glog.V(2).Infof("flags %s", spew.Sdump(flags))
+
+			// receive mesh configuration
+			mesh, err := cmd.ReadMeshConfig(flags.meshconfig)
+			if err != nil {
+				return multierror.Prefix(err, "failed to read mesh configuration.")
+			}
+
+			options := inject.InitializerOptions{
+				ResyncPeriod: flags.resyncPeriod,
+				Hub:          flags.hub,
+				Tag:          flags.tag,
+				InjectionPolicy: map[string]inject.InjectionPolicy{
+					// default off until feature is fully deployed in test clusters.
+					flags.namespace: inject.InjectionPolicyOff,
+				},
+			}
+			initializer := inject.NewInitializer(client, mesh, options)
+
+			stop := make(chan struct{})
+			go initializer.Run(stop)
+			cmd.WaitSignal(stop)
+
+			return nil
+		},
+	}
+
+	root.PersistentFlags().StringVar(&flags.hub, "hub", "docker.io/istio", "Docker hub")
+	root.PersistentFlags().StringVar(&flags.tag, "tag", "0.1", "Docker tag")
+	root.PersistentFlags().StringVar(&flags.namespace, "namespace", v1.NamespaceAll, "Namespace managed by initializer")
+
+	root.PersistentFlags().StringVar(&flags.kubeconfig, "kubeconfig", "",
+		"Use a Kubernetes configuration file instead of in-cluster configuration")
+	root.PersistentFlags().StringVar(&flags.meshconfig, "meshConfig", "/etc/istio/config/mesh",
+		fmt.Sprintf("File name for Istio mesh configuration"))
+	root.PersistentFlags().DurationVar(&flags.resyncPeriod, "resync", time.Second,
+		"Initializers resync interval")
+
+	cmd.AddFlags(root)
+
+	return root
+}
+
+func main() {
+	if err := getRootCmd().Execute(); err != nil {
+		os.Exit(-1)
+	}
+}

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -2,3 +2,4 @@ client
 server
 pilot-agent
 pilot-discovery
+sidecar-initializer

--- a/docker/Dockerfile.sidecar_initializer
+++ b/docker/Dockerfile.sidecar_initializer
@@ -1,0 +1,3 @@
+FROM scratch
+ADD sidecar-initializer /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/sidecar-initializer"]

--- a/platform/kube/inject/BUILD
+++ b/platform/kube/inject/BUILD
@@ -2,12 +2,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["inject.go"],
+    srcs = [
+        "initializer.go",
+        "inject.go",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//model:go_default_library",
         "//proxy:go_default_library",
+        "//tools/version:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@io_istio_api//:go_default_library",
         "@io_k8s_api//apps/v1beta1:go_default_library",
@@ -15,9 +20,15 @@ go_library(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//extensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/fields:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_apimachinery//pkg/util/intstr:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/strategicpatch:go_default_library",
         "@io_k8s_apimachinery//pkg/util/yaml:go_default_library",
+        "@io_k8s_apimachinery//pkg/watch:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
+        "@io_k8s_client_go//tools/cache:go_default_library",
     ],
 )
 
@@ -31,5 +42,7 @@ go_test(
         "//proxy:go_default_library",
         "//test/util:go_default_library",
         "@io_istio_api//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/platform/kube/inject/initializer.go
+++ b/platform/kube/inject/initializer.go
@@ -1,0 +1,433 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inject
+
+// NOTE: This tool only exists because kubernetes does not support
+// dynamic/out-of-tree admission controller for transparent proxy
+// injection. This file should be removed as soon as a proper kubernetes
+// admission controller is written for istio.
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/golang/glog"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	proxyconfig "istio.io/api/proxy/v1/config"
+	"istio.io/pilot/tools/version"
+)
+
+const initializerName = "sidecar.initializer.istio.io"
+
+type InitializerOptions struct {
+	InjectionPolicy map[string]InjectionPolicy
+	ResyncPeriod    time.Duration
+	// TODO - pull base template from ConfigMap
+	Hub string
+	Tag string
+}
+
+type Initializer struct {
+	clientset   kubernetes.Interface
+	mesh        *proxyconfig.ProxyMeshConfig
+	controllers []cache.Controller
+	options     InitializerOptions
+}
+
+func NewInitializer(clientset kubernetes.Interface, mesh *proxyconfig.ProxyMeshConfig, options InitializerOptions) *Initializer {
+	i := &Initializer{
+		clientset: clientset,
+		mesh:      mesh,
+		options:   options,
+	}
+
+	kinds := []struct {
+		resource   string
+		getter     cache.Getter
+		objType    runtime.Object
+		initialize func(in interface{}) error
+	}{
+		{
+			"deployments",
+			clientset.AppsV1beta1().RESTClient(),
+			&appsv1beta1.Deployment{},
+			i.initializeDeployment,
+		},
+		{
+			"statefulsets",
+			clientset.AppsV1beta1().RESTClient(),
+			&appsv1beta1.StatefulSet{},
+			i.initializeStatefulSet,
+		},
+		{
+			"jobs",
+			clientset.BatchV1().RESTClient(),
+			&batchv1.Job{},
+			i.initializeJob,
+		},
+		{
+			"daemonsets",
+			clientset.ExtensionsV1beta1().RESTClient(),
+			&v1beta1.DaemonSet{},
+			i.initializeDaemonSet,
+		},
+		{
+			"replicasets",
+			clientset.ExtensionsV1beta1().RESTClient(),
+			&v1beta1.ReplicaSet{},
+			i.initializeReplicaSet,
+		},
+		{
+			"replicationcontrollers",
+			clientset.CoreV1().RESTClient(),
+			&v1.ReplicationController{},
+			i.initializeReplicationController,
+		},
+		{
+			"pods",
+			clientset.CoreV1().RESTClient(),
+			&v1.Pod{},
+			i.initializePod,
+		},
+	}
+
+	for _, kind := range kinds {
+		kind := kind // capture the current value of `kind`
+
+		watchList := cache.NewListWatchFromClient(kind.getter, kind.resource,
+			v1.NamespaceAll, fields.Everything())
+
+		// Wrap the returned watchlist to workaround the inability to include
+		// the `IncludeUninitialized` list option when setting up watch clients.
+		includeUninitializedWatchList := &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				options.IncludeUninitialized = true
+				return watchList.List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.IncludeUninitialized = true
+				return watchList.Watch(options)
+			},
+		}
+
+		_, controller := cache.NewInformer(includeUninitializedWatchList, kind.objType, i.options.ResyncPeriod,
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					if err := kind.initialize(obj); err != nil {
+						glog.Errorf("Could not initialize %s: %v", kind.resource, err)
+					}
+				},
+			},
+		)
+		i.controllers = append(i.controllers, controller)
+	}
+	return i
+}
+
+func (i *Initializer) initializerPresent(objectMeta *metav1.ObjectMeta) bool {
+	glog.V(2).Infof("Initializer status %v/%v policy=%q status=%q %v", objectMeta.Namespace, objectMeta.Name,
+		objectMeta.Annotations[istioSidecarAnnotationPolicyKey],
+		objectMeta.Annotations[istioSidecarAnnotationStatusKey],
+		objectMeta.Initializers)
+
+	if objectMeta.GetInitializers() == nil {
+		return false
+	}
+	pendingInitializers := objectMeta.GetInitializers().Pending
+	if initializerName != pendingInitializers[0].Name {
+		return false
+	}
+
+	return true
+}
+
+func (i *Initializer) modifyResource(objectMeta *metav1.ObjectMeta, templateObjectMeta *metav1.ObjectMeta, templateSpec *v1.PodSpec) error {
+	// Skip namespace(s) that we're not responsible for initializing.
+	namespacePolicy, ok := i.options.InjectionPolicy[objectMeta.Namespace]
+	if !ok {
+		if namespacePolicy, ok = i.options.InjectionPolicy[v1.NamespaceAll]; !ok {
+			namespacePolicy = InjectionPolicyOff
+		}
+	}
+	if namespacePolicy == InjectionPolicyOff {
+		return nil
+	}
+
+	// Remove self from the list of pending Initializers while
+	// preserving ordering.
+	if pending := objectMeta.GetInitializers().Pending; len(pending) == 1 {
+		objectMeta.Initializers = nil
+	} else {
+		objectMeta.Initializers.Pending = append(pending[:0], pending[1:]...)
+	}
+
+	if !injectRequired(i.options.InjectionPolicy, objectMeta) {
+		return nil
+	}
+
+	glog.Infof("Initializing %s/%s", objectMeta.Namespace, objectMeta.Name)
+
+	p := &Params{
+		InitImage:         InitImageName(i.options.Hub, i.options.Tag),
+		ProxyImage:        ProxyImageName(i.options.Hub, i.options.Tag),
+		Verbosity:         DefaultVerbosity,
+		SidecarProxyUID:   DefaultSidecarProxyUID,
+		EnableCoreDump:    true,
+		Version:           version.Line(),
+		Mesh:              i.mesh,
+		MeshConfigMapName: "istio",
+	}
+	if err := injectIntoPodTemplateSpec(i.options.InjectionPolicy, p, objectMeta, templateSpec); err != nil {
+		return err
+	}
+
+	addAnnotation(objectMeta, p.Version)
+	if templateObjectMeta != nil {
+		addAnnotation(templateObjectMeta, p.Version) // templated annotation to avoid double-injection
+	}
+
+	return nil
+}
+
+func (i *Initializer) createTwoWayMergePatch(prev, curr interface{}, dataStruct interface{}) ([]byte, error) {
+	prevData, err := json.Marshal(prev)
+	if err != nil {
+		return nil, err
+	}
+	currData, err := json.Marshal(curr)
+	if err != nil {
+		return nil, err
+	}
+	return strategicpatch.CreateTwoWayMergePatch(prevData, currData, dataStruct)
+}
+
+func (i *Initializer) initializeDeployment(obj interface{}) error {
+	in := obj.(*appsv1beta1.Deployment)
+
+	if !i.initializerPresent(&in.ObjectMeta) {
+		return nil
+	}
+
+	o, err := runtime.NewScheme().DeepCopy(in)
+	if err != nil {
+		return err
+	}
+	out := o.(*appsv1beta1.Deployment)
+
+	if err := i.modifyResource(&out.ObjectMeta, &out.Spec.Template.ObjectMeta, &out.Spec.Template.Spec); err != nil {
+		return err
+	}
+	patchBytes, err := i.createTwoWayMergePatch(in, out, appsv1beta1.Deployment{})
+	if err != nil {
+		return err
+	}
+	_, err = i.clientset.AppsV1beta1().Deployments(in.Namespace).Patch(in.Name, types.StrategicMergePatchType, patchBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *Initializer) initializeStatefulSet(obj interface{}) error {
+	in := obj.(*appsv1beta1.StatefulSet)
+	if !i.initializerPresent(&in.ObjectMeta) {
+		return nil
+	}
+
+	glog.Infof("Initializing statefulset: %s", in.Name)
+
+	o, err := runtime.NewScheme().DeepCopy(in)
+	if err != nil {
+		return err
+	}
+	out := o.(*appsv1beta1.StatefulSet)
+
+	if err := i.modifyResource(&out.ObjectMeta, &out.Spec.Template.ObjectMeta, &out.Spec.Template.Spec); err != nil {
+		return err
+	}
+	patchBytes, err := i.createTwoWayMergePatch(in, out, appsv1beta1.StatefulSet{})
+	if err != nil {
+		return err
+	}
+	_, err = i.clientset.AppsV1beta1().StatefulSets(in.Namespace).Patch(in.Name, types.StrategicMergePatchType, patchBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *Initializer) initializeJob(obj interface{}) error {
+	in := obj.(*batchv1.Job)
+	if !i.initializerPresent(&in.ObjectMeta) {
+		return nil
+	}
+
+	glog.Infof("Initializing job: %s", in.Name)
+
+	o, err := runtime.NewScheme().DeepCopy(in)
+	if err != nil {
+		return err
+	}
+	out := o.(*batchv1.Job)
+
+	if err := i.modifyResource(&out.ObjectMeta, &out.Spec.Template.ObjectMeta, &out.Spec.Template.Spec); err != nil {
+		return err
+	}
+	patchBytes, err := i.createTwoWayMergePatch(in, out, batchv1.Job{})
+	if err != nil {
+		return err
+	}
+	_, err = i.clientset.BatchV1().Jobs(in.Namespace).Patch(in.Name, types.StrategicMergePatchType, patchBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *Initializer) initializeDaemonSet(obj interface{}) error {
+	in := obj.(*v1beta1.DaemonSet)
+	if !i.initializerPresent(&in.ObjectMeta) {
+		return nil
+	}
+
+	glog.Infof("Initializing daemonset: %s", in.Name)
+
+	o, err := runtime.NewScheme().DeepCopy(in)
+	if err != nil {
+		return err
+	}
+	out := o.(*v1beta1.DaemonSet)
+
+	if err := i.modifyResource(&out.ObjectMeta, &out.Spec.Template.ObjectMeta, &out.Spec.Template.Spec); err != nil {
+		return err
+	}
+	patchBytes, err := i.createTwoWayMergePatch(in, out, v1beta1.DaemonSet{})
+	if err != nil {
+		return err
+	}
+	_, err = i.clientset.ExtensionsV1beta1().DaemonSets(in.Namespace).Patch(in.Name, types.StrategicMergePatchType, patchBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *Initializer) initializeReplicaSet(obj interface{}) error {
+	in := obj.(*v1beta1.ReplicaSet)
+	if !i.initializerPresent(&in.ObjectMeta) {
+		return nil
+	}
+
+	glog.Infof("Initializing replicaset: %s", in.Name)
+
+	o, err := runtime.NewScheme().DeepCopy(in)
+	if err != nil {
+		return err
+	}
+	out := o.(*v1beta1.ReplicaSet)
+
+	if err := i.modifyResource(&out.ObjectMeta, &out.Spec.Template.ObjectMeta, &out.Spec.Template.Spec); err != nil {
+		return err
+	}
+	patchBytes, err := i.createTwoWayMergePatch(in, out, v1beta1.ReplicaSet{})
+	if err != nil {
+		return err
+	}
+	_, err = i.clientset.ExtensionsV1beta1().ReplicaSets(in.Namespace).Patch(in.Name, types.StrategicMergePatchType, patchBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *Initializer) initializeReplicationController(obj interface{}) error {
+	in := obj.(*v1.ReplicationController)
+	if !i.initializerPresent(&in.ObjectMeta) {
+		return nil
+	}
+
+	glog.Infof("Initializing replicationcontroller: %s", in.Name)
+
+	o, err := runtime.NewScheme().DeepCopy(in)
+	if err != nil {
+		return err
+	}
+	out := o.(*v1.ReplicationController)
+
+	if err := i.modifyResource(&out.ObjectMeta, &out.Spec.Template.ObjectMeta, &out.Spec.Template.Spec); err != nil {
+		return err
+	}
+	patchBytes, err := i.createTwoWayMergePatch(in, out, v1.ReplicationController{})
+	if err != nil {
+		return err
+	}
+	_, err = i.clientset.CoreV1().ReplicationControllers(in.Namespace).Patch(in.Name, types.StrategicMergePatchType, patchBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *Initializer) initializePod(obj interface{}) error {
+	return nil // skip pod processing altogether
+
+	in := obj.(*v1.Pod)
+	if !i.initializerPresent(&in.ObjectMeta) {
+		return nil
+	}
+
+	glog.Infof("Initializing pod: %v", in)
+	return nil
+
+	o, err := runtime.NewScheme().DeepCopy(in)
+	if err != nil {
+		return err
+	}
+	out := o.(*v1.Pod)
+
+	if err := i.modifyResource(&out.ObjectMeta, nil, &out.Spec); err != nil {
+		return err
+	}
+	patchBytes, err := i.createTwoWayMergePatch(in, out, v1.Pod{})
+	if err != nil {
+		return err
+	}
+	_, err = i.clientset.CoreV1().Pods(in.Namespace).Patch(in.Name, types.StrategicMergePatchType, patchBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *Initializer) Run(stopCh <-chan struct{}) {
+	glog.Info("Starting the Kubernetes initializer...")
+	glog.Infof("Initializer name set to: %s", initializerName)
+
+	for _, controller := range i.controllers {
+		go controller.Run(stopCh)
+	}
+}

--- a/platform/kube/inject/initializer_test.go
+++ b/platform/kube/inject/initializer_test.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inject
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInjectRequired(t *testing.T) {
+	cases := []struct {
+		policy map[string]InjectionPolicy
+		meta   *metav1.ObjectMeta
+		want   bool
+	}{
+		{
+			policy: map[string]InjectionPolicy{v1.NamespaceAll: InjectionPolicyOptOut},
+			meta: &metav1.ObjectMeta{
+				Name:        "no-policy",
+				Namespace:   "test-namespace",
+				Annotations: map[string]string{},
+			},
+			want: true,
+		},
+		{
+			policy: map[string]InjectionPolicy{v1.NamespaceAll: InjectionPolicyOptOut},
+			meta: &metav1.ObjectMeta{
+				Name:        "default-policy",
+				Namespace:   "test-namespace",
+				Annotations: map[string]string{istioSidecarAnnotationPolicyKey: istioSidecarAnnotationPolicyValueDefault},
+			},
+			want: true,
+		},
+		{
+			policy: map[string]InjectionPolicy{v1.NamespaceAll: InjectionPolicyOptOut},
+			meta: &metav1.ObjectMeta{
+				Name:        "force-on-policy",
+				Namespace:   "test-namespace",
+				Annotations: map[string]string{istioSidecarAnnotationPolicyKey: istioSidecarAnnotationPolicyValueForceOn},
+			},
+			want: true,
+		},
+		{
+			policy: map[string]InjectionPolicy{v1.NamespaceAll: InjectionPolicyOptOut},
+			meta: &metav1.ObjectMeta{
+				Name:        "force-off-policy",
+				Namespace:   "test-namespace",
+				Annotations: map[string]string{istioSidecarAnnotationPolicyKey: istioSidecarAnnotationPolicyValueForceOff},
+			},
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		if got := injectRequired(c.policy, c.meta); got != c.want {
+			t.Errorf("injectRequired(%v, %v) got %v want %v", c.policy, c.meta, got, c.want)
+		}
+	}
+}

--- a/platform/kube/inject/testdata/auth.cert-dir.yaml.injected
+++ b/platform/kube/inject/testdata/auth.cert-dir.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/platform/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/auth.yaml.injected
+++ b/platform/kube/inject/testdata/auth.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/platform/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/frontend.yaml.injected
+++ b/platform/kube/inject/testdata/frontend.yaml.injected
@@ -15,6 +15,8 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: frontend
 spec:
@@ -22,9 +24,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-always.yaml.injected
+++ b/platform/kube/inject/testdata/hello-always.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/platform/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-ignore.yaml
+++ b/platform/kube/inject/testdata/hello-ignore.yaml
@@ -2,12 +2,12 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: hello
+  annotations:
+    policy.sidecar.istio.io: "policy.sidecar.istio.io/force-off"
 spec:
   replicas: 7
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: ignored
       labels:
         app: hello
         tier: backend

--- a/platform/kube/inject/testdata/hello-ignore.yaml.injected
+++ b/platform/kube/inject/testdata/hello-ignore.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    policy.sidecar.istio.io: policy.sidecar.istio.io/force-off
   creationTimestamp: null
   name: hello
 spec:
@@ -8,8 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: ignored
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-multi.yaml.injected
+++ b/platform/kube/inject/testdata/hello-multi.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello-v1
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +82,8 @@ status: {}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello-v2
 spec:
@@ -90,9 +91,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-never.yaml.injected
+++ b/platform/kube/inject/testdata/hello-never.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello-probes.yaml.injected
+++ b/platform/kube/inject/testdata/hello-probes.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/hello.yaml.injected
+++ b/platform/kube/inject/testdata/hello.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/multi-init.yaml.injected
+++ b/platform/kube/inject/testdata/multi-init.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/platform/kube/inject/testdata/statefulset.yaml.injected
+++ b/platform/kube/inject/testdata/statefulset.yaml.injected
@@ -1,6 +1,8 @@
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
+  annotations:
+    status.sidecar.istio.io: injected-version-TODO
   creationTimestamp: null
   name: hello
 spec:
@@ -8,9 +10,6 @@ spec:
   serviceName: hello
   template:
     metadata:
-      annotations:
-        alpha.istio.io/sidecar: injected
-        alpha.istio.io/version: "12345678"
       creationTimestamp: null
       labels:
         app: hello

--- a/prow/pilot-e2e-smoketest.sh
+++ b/prow/pilot-e2e-smoketest.sh
@@ -19,6 +19,8 @@
 # Smoketest script triggered by Prow. #
 #######################################
 
+exit 1
+
 # Exit immediately for non zero status
 set -e
 # Check unset variables

--- a/prow/pilot-postsubmit.sh
+++ b/prow/pilot-postsubmit.sh
@@ -19,6 +19,8 @@
 # Postsubmit script triggered by Prow. #
 ########################################
 
+exit 1
+
 # Exit immediately for non zero status
 set -e
 # Check unset variables

--- a/prow/pilot-presubmit.sh
+++ b/prow/pilot-presubmit.sh
@@ -19,6 +19,8 @@
 # Presubmit script triggered by Prow. #
 #######################################
 
+exit 1
+
 # Exit immediately for non zero status
 set -e
 # Check unset variables

--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -86,6 +86,10 @@ func init() {
 
 	// If specified, only run one test
 	flag.StringVar(&testType, "testtype", "", "Select test to run (default is all tests)")
+
+	// Keep disabled until default no-op initializer is distributed
+	// and running in test clusters.
+	flag.BoolVar(&params.UseInitializer, "use-initializer", false, "Use k8s sidecar initializer")
 }
 
 type test interface {

--- a/test/integration/testdata/app.yaml.tmpl
+++ b/test/integration/testdata/app.yaml.tmpl
@@ -31,6 +31,10 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+{{if eq .injectProxy "false"}}
+  annotations:
+    policy.sidecar.istio.io: "policy.sidecar.istio.io/force-off"
+{{end}}
   name: {{.deployment}}
 spec:
   replicas: 1

--- a/test/integration/testdata/ca.yaml.tmpl
+++ b/test/integration/testdata/ca.yaml.tmpl
@@ -7,6 +7,8 @@ metadata:
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
+  annotations:
+    policy.sidecar.istio.io: "policy.sidecar.istio.io/force-off"
   name: istio-ca
 spec:
   replicas: 1

--- a/test/integration/testdata/egress-proxy.yaml.tmpl
+++ b/test/integration/testdata/egress-proxy.yaml.tmpl
@@ -18,6 +18,8 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    policy.sidecar.istio.io: "policy.sidecar.istio.io/force-off"
   name: istio-egress
 spec:
   replicas: 1

--- a/test/integration/testdata/ingress-proxy.yaml.tmpl
+++ b/test/integration/testdata/ingress-proxy.yaml.tmpl
@@ -21,6 +21,8 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    policy.sidecar.istio.io: "policy.sidecar.istio.io/force-off"
   name: istio-ingress
 spec:
   replicas: 1

--- a/test/integration/testdata/initializer-config.yaml.tmpl
+++ b/test/integration/testdata/initializer-config.yaml.tmpl
@@ -1,0 +1,18 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: InitializerConfiguration
+metadata:
+  name: istio-sidecar
+initializers:
+  - name: sidecar.initializer.istio.io
+    rules:
+      - apiGroups:
+          - "*"
+        apiVersions:
+          - "*"
+        resources:
+          - deployments
+          - statefulsets
+          - jobs
+          - daemonsets
+          # - replicasets
+          # - replicationcontrollers

--- a/test/integration/testdata/initializer.yaml.tmpl
+++ b/test/integration/testdata/initializer.yaml.tmpl
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-sidecar-initializer-service-account
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: istio-sidecar-initializer
+  annotations:
+    policy.sidecar.istio.io: "policy.sidecar.istio.io/force-off"
+  initializers:
+    pending: []
+  labels:
+    istio: istio-sidecar-initializer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: istio-sidecar-initializer
+      labels:
+        istio: sidecar-initializer
+      annotations:
+        policy.sidecar.istio.io: "policy.sidecar.istio.io/force-off"
+    spec:
+      serviceAccountName: istio-sidecar-initializer-service-account
+      containers:
+        - name: sidecar-initializer
+          image: {{.Hub}}/sidecar_initializer:{{.Tag}}
+          imagePullPolicy: Always
+          args:
+            - --hub={{.Hub}}
+            - --tag={{.Tag}}
+            - --namespace={{.Namespace}}
+            - -v=2
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/istio/config
+      volumes:
+      - name: config-volume
+        configMap:
+          name: istio

--- a/test/integration/testdata/mixer.yaml.tmpl
+++ b/test/integration/testdata/mixer.yaml.tmpl
@@ -20,6 +20,8 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    policy.sidecar.istio.io: "policy.sidecar.istio.io/force-off"
   name: istio-mixer
 spec:
   replicas: 1

--- a/test/integration/testdata/pilot.yaml.tmpl
+++ b/test/integration/testdata/pilot.yaml.tmpl
@@ -20,6 +20,8 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    policy.sidecar.istio.io: "policy.sidecar.istio.io/force-off"
   name: istio-pilot
 spec:
   replicas: 1

--- a/test/integration/testdata/rbac-beta.yaml.tmpl
+++ b/test/integration/testdata/rbac-beta.yaml.tmpl
@@ -39,6 +39,15 @@ rules:
   resources: ["serviceaccounts"]
   verbs: ["get", "watch", "list"]
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-sidecar-initializer
+rules:
+- apiGroups: ["*"]
+  resources: ["deployments", "statefulsets", "jobs", "daemonsets", "replicasets", "replicationcontrollers", "pods"]
+  verbs: ["initialize", "patch", "watch", "list"]
+---
 # Grant permissions to the Pilot/discovery.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -107,5 +116,19 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: istio-pilot
+  apiGroup: rbac.authorization.k8s.io
+---
+# Gran permissions to the Sidecar initializer
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-sidecar-initializer-admin-role-binding
+subjects:
+- kind: ServiceAccount
+  name: istio-sidecar-initializer-service-account
+  namespace: {{.Namespace}}
+roleRef:
+  kind: ClusterRole
+  name: istio-sidecar-initializer
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/test/integration/testdata/zipkin.yaml
+++ b/test/integration/testdata/zipkin.yaml
@@ -14,6 +14,8 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    policy.sidecar.istio.io: "policy.sidecar.istio.io/force-off"
   name: zipkin
 spec:
   replicas: 1


### PR DESCRIPTION
NOTE: Initializer resources are inherently cluster scoped. The only
way to enforce namespace scope is via the initializer implementation,
e.g. all initializer deployments in the cluster receive requests but
only modify resources for specified namespace(s). 

This feature can be introduce in stages to minimize disruption to the shared test clusters.

Step (1) - Enable initializer deployment with namespace policy "opt-in" and k8s initializer configuration disabled. 
Step (2) - Enable initializer configuration. At this point all test instances will be using initializer but nothing will be injected yet.
Step (3) - Disable manual injection in tests and and enable auto-injection option.



