### PR TITLE
Set require_client_certificate in SSL context

### DIFF
--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -510,6 +510,7 @@ type SSLContext struct {
 	CertChainFile  string `json:"cert_chain_file"`
 	PrivateKeyFile string `json:"private_key_file"`
 	CaCertFile     string `json:"ca_cert_file,omitempty"`
+	RequireClientCertificate bool `json:"require_client_certificate"`
 }
 
 // SSLContextExternal definition

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -507,10 +507,10 @@ func (listeners Listeners) GetByAddress(addr string) *Listener {
 
 // SSLContext definition
 type SSLContext struct {
-	CertChainFile  string `json:"cert_chain_file"`
-	PrivateKeyFile string `json:"private_key_file"`
-	CaCertFile     string `json:"ca_cert_file,omitempty"`
-	RequireClientCertificate bool `json:"require_client_certificate"`
+	CertChainFile            string `json:"cert_chain_file"`
+	PrivateKeyFile           string `json:"private_key_file"`
+	CaCertFile               string `json:"ca_cert_file,omitempty"`
+	RequireClientCertificate bool   `json:"require_client_certificate"`
 }
 
 // SSLContextExternal definition

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -40,9 +40,9 @@ const (
 // buildListenerSSLContext returns an SSLContext struct.
 func buildListenerSSLContext(certsDir string) *SSLContext {
 	return &SSLContext{
-		CertChainFile:  certsDir + "/" + certChainFilename,
-		PrivateKeyFile: certsDir + "/" + keyFilename,
-		CaCertFile:     certsDir + "/" + rootCertFilename,
+		CertChainFile:            certsDir + "/" + certChainFilename,
+		PrivateKeyFile:           certsDir + "/" + keyFilename,
+		CaCertFile:               certsDir + "/" + rootCertFilename,
 		RequireClientCertificate: true,
 	}
 }

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -43,6 +43,7 @@ func buildListenerSSLContext(certsDir string) *SSLContext {
 		CertChainFile:  certsDir + "/" + certChainFilename,
 		PrivateKeyFile: certsDir + "/" + keyFilename,
 		CaCertFile:     certsDir + "/" + rootCertFilename,
+		RequireClientCertificate: true,
 	}
 }
 

--- a/proxy/envoy/route_test.go
+++ b/proxy/envoy/route_test.go
@@ -54,6 +54,7 @@ func TestBuildListenerSSLContext(t *testing.T) {
 	const dir = "/some/testing/dir"
 	context := buildListenerSSLContext(dir)
 	if !context.RequireClientCertificate {
-		t.Errorf("buildListenerSSLContext(%v) => Got RequireClientCertificate: true, expected false.", dir)
+		t.Errorf("buildListenerSSLContext(%v) => Got RequireClientCertificate: %v, expected true.",
+			dir, context.RequireClientCertificate)
 	}
 }

--- a/proxy/envoy/route_test.go
+++ b/proxy/envoy/route_test.go
@@ -49,3 +49,11 @@ func TestSharedHost(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildListenerSSLContext(t *testing.T) {
+	const dir = "/some/testing/dir"
+	context := buildListenerSSLContext(dir)
+	if !context.RequireClientCertificate {
+		t.Errorf("buildListenerSSLContext(%v) => Got RequireClientCertificate: true, expected false.", dir)
+	}
+}

--- a/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
@@ -319,7 +319,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -348,7 +349,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -420,7 +422,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },

--- a/proxy/envoy/testdata/lds-v0-none-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none-auth.json.golden
@@ -255,7 +255,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -284,7 +285,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -356,7 +358,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },

--- a/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
@@ -255,7 +255,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -284,7 +285,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -356,7 +358,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },

--- a/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
@@ -255,7 +255,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -284,7 +285,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -356,7 +358,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },

--- a/proxy/envoy/testdata/lds-v1-none-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none-auth.json.golden
@@ -255,7 +255,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -284,7 +285,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -356,7 +358,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },

--- a/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
@@ -255,7 +255,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -284,7 +285,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },
@@ -356,7 +358,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/certs/cert-chain.pem",
      "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem"
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
     },
     "bind_to_port": false
    },


### PR DESCRIPTION
Fixes #1002 

This fix causes pilot to configure Envoy to check client certificates on upstream proxy listeners.