### PR TITLE
Makefile: proper deps for the setup target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@
 SHELL := /bin/bash
 
 .PHONY: setup
-setup:
-	@ln -s ~/.kube/config platform/kube/
+setup: platform/kube/config
 	@bin/init.sh
 
 .PHONY: build
@@ -34,3 +33,7 @@ test: build
 .PHONY: lint
 lint: build
 	@bin/check.sh
+
+platform/kube/config:
+	@ln -s ~/.kube/config platform/kube/
+


### PR DESCRIPTION
this config is linked, but not forcefully linked, during setup.

```
[vbatts@getdown] (master) ~/src/github.com/istio/pilot$ make
ln: failed to create symbolic link 'platform/kube/config': File exists
make: *** [Makefile:19: setup] Error 1
```

With this, a user could put their own config without getting clobbered,
or no error on `make` when the PHONY setup runs everytime.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>