### PR TITLE
[wip] local development environment for pilot

### DIFF
--- a/bin/push-docker
+++ b/bin/push-docker
@@ -51,7 +51,7 @@ done
 bin=$(bazel info bazel-bin)
 bazel build --output_groups=static //cmd/... //test/...
 \cp -f  "${bin}/test/client/client.static" docker/client
-\cp -f  "${bin}/test/server/server.static" docker/server
+\cp -f  "${bin}/test/server/main/main.static" docker/server
 \cp -f  "${bin}/cmd/pilot-agent/pilot-agent.static" docker/pilot-agent
 \cp -f  "${bin}/cmd/pilot-discovery/pilot-discovery.static" docker/pilot-discovery
 

--- a/cmd/pilot-agent/main.go
+++ b/cmd/pilot-agent/main.go
@@ -32,6 +32,7 @@ import (
 )
 
 var (
+	binarypath string
 	configpath string
 	meshconfig string
 	sidecar    proxy.Sidecar
@@ -87,7 +88,7 @@ var (
 				}
 			}
 
-			watcher := envoy.NewWatcher(mesh, role, configpath)
+			watcher := envoy.NewWatcher(mesh, role, binarypath, configpath)
 			ctx, cancel := context.WithCancel(context.Background())
 			go watcher.Run(ctx)
 
@@ -103,6 +104,8 @@ var (
 func init() {
 	proxyCmd.PersistentFlags().StringVar(&meshconfig, "meshconfig", "/etc/istio/config/mesh",
 		"File name for Istio mesh configuration")
+	proxyCmd.PersistentFlags().StringVar(&binarypath, "binarypath", "/usr/local/bin/envoy",
+		"Path to proxy binary")
 	proxyCmd.PersistentFlags().StringVar(&configpath, "configpath", "/etc/istio/proxy",
 		"Path to generated proxy configuration directory")
 	proxyCmd.PersistentFlags().StringVar(&sidecar.IPAddress, "ip", "",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -40,6 +40,5 @@ go_binary(
         "//docker:certs",
     ],
     library = ":go_default_library",
-    tags = ["manual"],
     visibility = ["//visibility:public"],
 )

--- a/test/local/BUILD.bazel
+++ b/test/local/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//model:go_default_library",
+        "//test/server:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "local",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/test/local/BUILD.bazel
+++ b/test/local/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//model:go_default_library",
+        "//proxy:go_default_library",
+        "//proxy/envoy:go_default_library",
         "//test/server:go_default_library",
     ],
 )

--- a/test/local/main.go
+++ b/test/local/main.go
@@ -1,0 +1,146 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main is used for local testing of Istio proxy mesh
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"istio.io/pilot/model"
+	"istio.io/pilot/proxy"
+	"istio.io/pilot/proxy/envoy"
+	"istio.io/pilot/test/server"
+)
+
+const (
+	localhost = "127.0.0.1"
+	http      = "http"
+	grpc      = "grpc"
+)
+
+var (
+	baseHTTPPort  int
+	baseGRPCPort  int
+	n             int
+	host          string
+	discoveryPort int
+
+	service = &model.Service{
+		Hostname: host,
+		Address:  localhost,
+		Ports: []*model.Port{{
+			Name:     http,
+			Port:     8000,
+			Protocol: model.ProtocolHTTP,
+		}, {
+			Name:     grpc,
+			Port:     8001,
+			Protocol: model.ProtocolGRPC,
+		}},
+	}
+)
+
+func init() {
+	flag.IntVar(&baseHTTPPort, http, 9000, "Base HTTP/1.1 port")
+	flag.IntVar(&baseGRPCPort, grpc, 9100, "Base gRPC port")
+	flag.IntVar(&n, "n", 10, "Number of instances")
+	flag.IntVar(&discoveryPort, "xds", 7000, "xDS server port")
+	flag.StringVar(&host, "host", "dev", "Service hostname")
+}
+
+func main() {
+	// set global settings
+	mesh := proxy.DefaultMeshConfig()
+	mesh.MixerAddress = ""
+	mesh.DiscoveryAddress = fmt.Sprintf("%s:%d", localhost, discoveryPort)
+
+	// spawn service instances
+	for i := 0; i < n; i++ {
+		go server.RunHTTP(baseHTTPPort+i, fmt.Sprintf("v%d", i))
+		go server.RunGRPC(baseGRPCPort+i, fmt.Sprintf("v%d", i), "", "")
+	}
+
+	// spawn proxy
+	watcher := envoy.NewWatcher(mesh, role, configpath)
+	ctx, cancel := context.WithCancel(context.Background())
+	go watcher.Run(ctx)
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+}
+
+type registry struct{}
+
+func (_ registry) Services() []*model.Service {
+	return []*model.Service{service}
+}
+
+func (_ registry) GetService(hostname string) (*model.Service, bool) {
+	if hostname == host {
+		return service, true
+	}
+	return nil, false
+}
+
+func (_ registry) Instances(hostname string, ports []string, tagsList model.TagsList) []*model.ServiceInstance {
+	if hostname != host {
+		return nil
+	}
+
+	out := make([]*model.ServiceInstance, 0)
+
+	for _, port := range ports {
+		var base int
+		if port == http {
+			base = baseHTTPPort
+		} else if port == grpc {
+			base = baseGRPCPort
+		} else {
+			continue
+		}
+
+		for i := 0; i < n; i++ {
+			tags := map[string]string{"version": fmt.Sprintf("v%d", i)}
+			if !tagsList.HasSubsetOf(tags) {
+				continue
+			}
+
+			svcPort, _ := service.Ports.Get(port)
+			instance := &model.ServiceInstance{
+				Endpoint: model.NetworkEndpoint{
+					Address:     localhost,
+					Port:        base + i,
+					ServicePort: svcPort,
+				},
+				Service: service,
+				Tags:    tags,
+			}
+			out = append(out, instance)
+		}
+	}
+
+	return out
+}
+
+func (_ registry) HostInstances(addrs map[string]bool) []*model.ServiceInstance {
+	// TODO: assume no inbound routes
+	return nil
+}

--- a/test/server/BUILD.bazel
+++ b/test/server/BUILD.bazel
@@ -1,21 +1,14 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
     srcs = ["echo.go"],
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = [
         "//test/grpcecho:go_default_library",
-        "@com_github_spf13_pflag//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_google_grpc//metadata:go_default_library",
         "@org_golang_x_net//context:go_default_library",
     ],
-)
-
-go_binary(
-    name = "server",
-    library = ":go_default_library",
-    visibility = ["//visibility:public"],
 )

--- a/test/server/main/BUILD.bazel
+++ b/test/server/main/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//test/server:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "main",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/test/server/main/main.go
+++ b/test/server/main/main.go
@@ -1,0 +1,63 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An example implementation of an echo backend.
+//
+// To test flaky HTTP service recovery, this backend has a special features.
+// If the "?codes=" query parameter is used it will return HTTP response codes other than 200
+// according to a probability distribution.
+// For example, ?codes=500:90,200:10 returns 500 90% of times and 200 10% of times
+// For example, ?codes=500:1,200:1 returns 500 50% of times and 200 50% of times
+// For example, ?codes=501:999,401:1 returns 500 99.9% of times and 401 0.1% of times.
+// For example, ?codes=500,200 returns 500 50% of times and 200 50% of times
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	flag "github.com/spf13/pflag"
+	"istio.io/pilot/test/server"
+)
+
+var (
+	ports     []int
+	grpcPorts []int
+	version   string
+
+	crt, key string
+)
+
+func init() {
+	flag.IntSliceVar(&ports, "port", []int{8080}, "HTTP/1.1 ports")
+	flag.IntSliceVar(&grpcPorts, "grpc", []int{7070}, "GRPC ports")
+	flag.StringVar(&version, "version", "", "Version string")
+	flag.StringVar(&crt, "crt", "", "gRPC TLS server-side certificate")
+	flag.StringVar(&key, "key", "", "gRPC TLS server-side key")
+}
+
+func main() {
+	flag.Parse()
+	for _, port := range ports {
+		go server.RunHTTP(port, version)
+	}
+	for _, grpcPort := range grpcPorts {
+		go server.RunGRPC(grpcPort, version, crt, key)
+	}
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+}


### PR DESCRIPTION
This let you spin up local proxy, agent, discovery, and mixer, and issue requests as if through the client-side proxy.

E.g.:
```
go run test/local/main.go -logtostderr -envoy bazel-genfiles/proxy/envoy/envoy -v 2
curl localhost:8000  --header 'Host: dev.local'
```

This should also work on mac (without mixer) if you use darwin build of Envoy.