### PR TITLE
HTTP Proxy implementation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -469,7 +469,7 @@ go_proto_library(
     ],
 )
     """,
-    commit = "af5afdafc95826a5716facc2ea025f1e27bb8225",  # June 8, 2017
+    commit = "846cbe55455f0b3b2ed742b52edc520cc94326a9",  # Aug 18, 2017
     remote = "https://github.com/istio/api.git",
 )
 

--- a/proxy/envoy/discovery.go
+++ b/proxy/envoy/discovery.go
@@ -473,22 +473,8 @@ func (ds *DiscoveryService) ListRoutes(request *restful.Request, response *restf
 			return
 		}
 
-		// route-config-name holds the listener port
 		routeConfigName := request.PathParameter(RouteConfigName)
-		port, err := strconv.Atoi(routeConfigName)
-		if err != nil {
-			errorResponse(response, http.StatusNotFound,
-				fmt.Sprintf("Unexpected %s %q", RouteConfigName, routeConfigName))
-			return
-		}
-
-		httpRouteConfigs := buildRDSRoutes(ds.Mesh, role, ds, ds)
-		routeConfig, ok := httpRouteConfigs[port]
-		if !ok {
-			errorResponse(response, http.StatusNotFound,
-				fmt.Sprintf("Missing route config for port %d", port))
-			return
-		}
+		routeConfig := buildRDSRoute(ds.Mesh, role, routeConfigName, ds.ServiceDiscovery, ds.IstioConfigStore)
 		if out, err = json.MarshalIndent(routeConfig, " ", " "); err != nil {
 			errorResponse(response, http.StatusInternalServerError, err.Error())
 			return

--- a/proxy/envoy/discovery_test.go
+++ b/proxy/envoy/discovery_test.go
@@ -427,6 +427,20 @@ func TestListenerDiscoveryIngress(t *testing.T) {
 	compareResponse(response, "testdata/lds-ingress.json", t)
 }
 
+func TestListenerDiscoveryHttpProxy(t *testing.T) {
+	mesh := makeMeshConfig()
+	mesh.ProxyListenPort = 0
+	mesh.ProxyHttpPort = 15002
+	registry := memory.Make(model.IstioConfigTypes)
+	ds := makeDiscoveryService(t, registry, &mesh)
+	url := fmt.Sprintf("/v1/listeners/%s/%s", ds.Mesh.IstioServiceCluster, mock.ProxyV0.ServiceNode())
+	response := makeDiscoveryRequest(ds, "GET", url, t)
+	compareResponse(response, "testdata/lds-httpproxy.json", t)
+	url = fmt.Sprintf("/v1/routes/15002/%s/%s", ds.Mesh.IstioServiceCluster, mock.ProxyV0.ServiceNode())
+	response = makeDiscoveryRequest(ds, "GET", url, t)
+	compareResponse(response, "testdata/rds-httpproxy.json", t)
+}
+
 func TestListenerDiscoveryEgress(t *testing.T) {
 	mesh := makeMeshConfig()
 	registry := memory.Make(model.IstioConfigTypes)

--- a/proxy/envoy/discovery_test.go
+++ b/proxy/envoy/discovery_test.go
@@ -436,7 +436,7 @@ func TestListenerDiscoveryHttpProxy(t *testing.T) {
 	url := fmt.Sprintf("/v1/listeners/%s/%s", ds.Mesh.IstioServiceCluster, mock.ProxyV0.ServiceNode())
 	response := makeDiscoveryRequest(ds, "GET", url, t)
 	compareResponse(response, "testdata/lds-httpproxy.json", t)
-	url = fmt.Sprintf("/v1/routes/15002/%s/%s", ds.Mesh.IstioServiceCluster, mock.ProxyV0.ServiceNode())
+	url = fmt.Sprintf("/v1/routes/%s/%s/%s", RDSAll, ds.Mesh.IstioServiceCluster, mock.ProxyV0.ServiceNode())
 	response = makeDiscoveryRequest(ds, "GET", url, t)
 	compareResponse(response, "testdata/rds-httpproxy.json", t)
 }

--- a/proxy/envoy/egress.go
+++ b/proxy/envoy/egress.go
@@ -27,7 +27,7 @@ import (
 
 func buildEgressListeners(mesh *proxyconfig.ProxyMeshConfig, egress proxy.Node) Listeners {
 	port := proxy.ParsePort(mesh.EgressProxyAddress)
-	listener := buildHTTPListener(mesh, egress, nil, WildcardAddress, port, true, false)
+	listener := buildHTTPListener(mesh, egress, nil, WildcardAddress, port, fmt.Sprintf("%d", port), false)
 	applyInboundAuth(listener, mesh)
 	return Listeners{listener}
 }

--- a/proxy/envoy/egress.go
+++ b/proxy/envoy/egress.go
@@ -45,8 +45,7 @@ func buildEgressRoutes(mesh *proxyconfig.ProxyMeshConfig, services model.Service
 	}
 	port := proxy.ParsePort(mesh.EgressProxyAddress)
 	configs := HTTPRouteConfigs{port: &HTTPRouteConfig{VirtualHosts: vhosts}}
-	configs.normalize()
-	return configs
+	return configs.normalize()
 }
 
 // buildEgressRoute translates an egress rule to an Envoy route

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -119,8 +119,7 @@ func buildIngressRoutes(mesh *proxyconfig.ProxyMeshConfig,
 	}
 
 	configs := HTTPRouteConfigs{80: rc, 443: rcTLS}
-	configs.normalize()
-	return configs, tlsAll
+	return configs.normalize(), tlsAll
 }
 
 // buildIngressRoute translates an ingress rule to an Envoy route

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -32,14 +32,14 @@ func buildIngressListeners(mesh *proxyconfig.ProxyMeshConfig,
 	config model.IstioConfigStore,
 	ingress proxy.Node) Listeners {
 	listeners := Listeners{
-		buildHTTPListener(mesh, ingress, nil, WildcardAddress, 80, true, true),
+		buildHTTPListener(mesh, ingress, nil, WildcardAddress, 80, "80", true),
 	}
 
 	// lack of SNI in Envoy implies that TLS secrets are attached to listeners
 	// therefore, we should first check that TLS endpoint is needed before shipping TLS listener
 	_, secret := buildIngressRoutes(mesh, discovery, config)
 	if secret != "" {
-		listener := buildHTTPListener(mesh, ingress, nil, WildcardAddress, 443, true, true)
+		listener := buildHTTPListener(mesh, ingress, nil, WildcardAddress, 443, "443", true)
 		listener.SSLContext = &SSLContext{
 			CertChainFile:  path.Join(proxy.IngressCertsPath, "tls.crt"),
 			PrivateKeyFile: path.Join(proxy.IngressCertsPath, "tls.key"),

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -46,7 +46,7 @@ const (
 	CDSName = "cds"
 
 	// RDSAll is the special name for HTTP PROXY route
-	RDSAll = "all"
+	RDSAll = "http_proxy"
 
 	// VirtualListenerName is the name for traffic capture listener
 	VirtualListenerName = "virtual"

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -45,6 +45,9 @@ const (
 	// CDSName is the name of cluster-discovery-service (CDS) cluster
 	CDSName = "cds"
 
+	// RDSAll is the special name for HTTP PROXY route
+	RDSAll = "all"
+
 	// VirtualListenerName is the name for traffic capture listener
 	VirtualListenerName = "virtual"
 

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -81,6 +81,9 @@ const (
 	// WildcardAddress binds to all IP addresses
 	WildcardAddress = "0.0.0.0"
 
+	// LocalhostAddress for local binding
+	LocalhostAddress = "127.0.0.1"
+
 	// IngressTraceOperation denotes the name of trace operation for Envoy
 	IngressTraceOperation = "ingress"
 
@@ -333,11 +336,40 @@ func (routes HTTPRouteConfigs) clusters() Clusters {
 	return out
 }
 
-func (routes HTTPRouteConfigs) normalize() {
+func (routes HTTPRouteConfigs) normalize() HTTPRouteConfigs {
+	out := make(HTTPRouteConfigs)
+
 	// sort HTTP routes by virtual hosts, rest should be deterministic
-	for _, routeConfig := range routes {
-		routeConfig.normalize()
+	for port, routeConfig := range routes {
+		out[port] = routeConfig.normalize()
 	}
+
+	return out
+}
+
+// combine creates a new route config that is the union of all HTTP routes.
+// note that the virtual hosts without an explicit port suffix (IP:PORT) are stripped
+// for all routes except the route for port 80.
+func (routes HTTPRouteConfigs) combine() *HTTPRouteConfig {
+	out := &HTTPRouteConfig{}
+	for port, config := range routes {
+		for _, host := range config.VirtualHosts {
+			vhost := &VirtualHost{
+				Name:   host.Name,
+				Routes: host.Routes,
+			}
+			for _, domain := range host.Domains {
+				if port == 80 || strings.Contains(domain, ":") {
+					vhost.Domains = append(vhost.Domains, domain)
+				}
+			}
+
+			if len(vhost.Domains) > 0 {
+				out.VirtualHosts = append(out.VirtualHosts, vhost)
+			}
+		}
+	}
+	return out.normalize()
 }
 
 // faults aggregates fault filters across virtual hosts in single http_conn_man
@@ -359,9 +391,11 @@ func (rc *HTTPRouteConfig) clusters() Clusters {
 	return out
 }
 
-func (rc *HTTPRouteConfig) normalize() {
-	hosts := rc.VirtualHosts
+func (rc *HTTPRouteConfig) normalize() *HTTPRouteConfig {
+	hosts := make([]*VirtualHost, len(rc.VirtualHosts))
+	copy(hosts, rc.VirtualHosts)
 	sort.Slice(hosts, func(i, j int) bool { return hosts[i].Name < hosts[j].Name })
+	return &HTTPRouteConfig{VirtualHosts: hosts}
 }
 
 // AccessLog definition.

--- a/proxy/envoy/testdata/envoy.json.golden
+++ b/proxy/envoy/testdata/envoy.json.golden
@@ -6,7 +6,7 @@
   },
   "admin": {
     "access_log_path": "/dev/stdout",
-    "address": "tcp://0.0.0.0:15000"
+    "address": "tcp://127.0.0.1:15000"
   },
   "cluster_manager": {
     "clusters": [

--- a/proxy/envoy/testdata/lds-httpproxy.json.golden
+++ b/proxy/envoy/testdata/lds-httpproxy.json.golden
@@ -16,7 +16,7 @@
        },
        "rds": {
         "cluster": "rds",
-        "route_config_name": "all",
+        "route_config_name": "http_proxy",
         "refresh_delay_ms": 10
        },
        "filters": [

--- a/proxy/envoy/testdata/lds-httpproxy.json.golden
+++ b/proxy/envoy/testdata/lds-httpproxy.json.golden
@@ -1,0 +1,55 @@
+{
+  "listeners": [
+   {
+    "address": "tcp://0.0.0.0:15002",
+    "name": "http_0.0.0.0_15002",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "15002",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "mixer_attributes": {
+           "target.ip": "10.1.1.0",
+           "target.uid": "kubernetes://v0.default"
+          },
+          "forward_attributes": {
+           "source.ip": "10.1.1.0",
+           "source.uid": "kubernetes://v0.default"
+          },
+          "quota_name": "RequestCount"
+         }
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": true
+   }
+  ]
+ }

--- a/proxy/envoy/testdata/lds-httpproxy.json.golden
+++ b/proxy/envoy/testdata/lds-httpproxy.json.golden
@@ -16,7 +16,7 @@
        },
        "rds": {
         "cluster": "rds",
-        "route_config_name": "15002",
+        "route_config_name": "all",
         "refresh_delay_ms": 10
        },
        "filters": [

--- a/proxy/envoy/testdata/lds-httpproxy.json.golden
+++ b/proxy/envoy/testdata/lds-httpproxy.json.golden
@@ -1,8 +1,8 @@
 {
   "listeners": [
    {
-    "address": "tcp://0.0.0.0:15002",
-    "name": "http_0.0.0.0_15002",
+    "address": "tcp://127.0.0.1:15002",
+    "name": "http_127.0.0.1_15002",
     "filters": [
      {
       "type": "read",

--- a/proxy/envoy/testdata/rds-httpproxy.json.golden
+++ b/proxy/envoy/testdata/rds-httpproxy.json.golden
@@ -1,0 +1,123 @@
+{
+  "virtual_hosts": [
+   {
+    "name": "hello.default.svc.cluster.local|http",
+    "domains": [
+     "hello:80",
+     "hello",
+     "hello.default:80",
+     "hello.default",
+     "hello.default.svc:80",
+     "hello.default.svc",
+     "hello.default.svc.cluster:80",
+     "hello.default.svc.cluster",
+     "hello.default.svc.cluster.local:80",
+     "hello.default.svc.cluster.local",
+     "10.1.0.0:80",
+     "10.1.0.0"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+     }
+    ]
+   },
+   {
+    "name": "hello.default.svc.cluster.local|http-status",
+    "domains": [
+     "hello:81",
+     "hello.default:81",
+     "hello.default.svc:81",
+     "hello.default.svc.cluster:81",
+     "hello.default.svc.cluster.local:81",
+     "10.1.0.0:81"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.81c187d71467b1608736c57bb0734f9ef9b68f7d"
+     }
+    ]
+   },
+   {
+    "name": "httpbin.default.svc.cluster.local|http",
+    "domains": [
+     "httpbin:80",
+     "httpbin",
+     "httpbin.default:80",
+     "httpbin.default",
+     "httpbin.default.svc:80",
+     "httpbin.default.svc",
+     "httpbin.default.svc.cluster:80",
+     "httpbin.default.svc.cluster",
+     "httpbin.default.svc.cluster.local:80",
+     "httpbin.default.svc.cluster.local"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "host_rewrite": "httpbin.default.svc.cluster.local",
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+     }
+    ]
+   },
+   {
+    "name": "httpsbin.default.svc.cluster.local|https",
+    "domains": [
+     "httpsbin:443",
+     "httpsbin.default:443",
+     "httpsbin.default.svc:443",
+     "httpsbin.default.svc.cluster:443",
+     "httpsbin.default.svc.cluster.local:443"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "host_rewrite": "httpsbin.default.svc.cluster.local",
+      "cluster": "out.242bc3028e0f3fe0682e6d972e167ab415b2321d"
+     }
+    ]
+   },
+   {
+    "name": "world.default.svc.cluster.local|http",
+    "domains": [
+     "world:80",
+     "world",
+     "world.default:80",
+     "world.default",
+     "world.default.svc:80",
+     "world.default.svc",
+     "world.default.svc.cluster:80",
+     "world.default.svc.cluster",
+     "world.default.svc.cluster.local:80",
+     "world.default.svc.cluster.local",
+     "10.2.0.0:80",
+     "10.2.0.0"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
+     }
+    ]
+   },
+   {
+    "name": "world.default.svc.cluster.local|http-status",
+    "domains": [
+     "world:81",
+     "world.default:81",
+     "world.default.svc:81",
+     "world.default.svc.cluster:81",
+     "world.default.svc.cluster.local:81",
+     "10.2.0.0:81"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.bde94496eb59ec2ed5b81392a1d32377960660b8"
+     }
+    ]
+   }
+  ]
+ }

--- a/test/integration/infra.go
+++ b/test/integration/infra.go
@@ -240,13 +240,11 @@ func (infra *infra) teardown() {
 }
 
 func (infra *infra) kubeApply(yaml string) error {
-	fmt.Println(yaml)
 	return util.RunInput(fmt.Sprintf("kubectl apply --kubeconfig %s -n %s -f -",
 		kubeconfig, infra.Namespace), yaml)
 }
 
 func (infra *infra) kubeDelete(yaml string) error {
-	fmt.Println(yaml)
 	return util.RunInput(fmt.Sprintf("kubectl delete --kubeconfig %s -n %s -f -",
 		kubeconfig, infra.Namespace), yaml)
 }


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
Adds HTTP routes on a dedicated HTTP proxy port for non-transparent addressing. Also, makes iptables method optional, and admin port optional.

```release-note
HTTP proxy support for client-side routing.
```
