### PR TITLE
Enabled setup install pre-requested go binaries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SHELL := /bin/bash
 
 .PHONY: setup
 setup: platform/kube/config
+	@bin/install-prereqs.sh
 	@bin/init.sh
 
 .PHONY: build


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
Fixed https://github.com/istio/pilot/issues/1072
