### PR TITLE
Enabled code coverage test in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ clean:
 test: build
 	@bazel test //...
 
+.PHONY: coverage
+coverage:
+	@bin/codecov.sh
+
 .PHONY: lint
 lint: build
 	@bin/check.sh


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

Fixed https://github.com/istio/pilot/issues/1073
