### PR TITLE
Use absolute name of PWD to match Bazel's behavior

### DIFF
--- a/bin/upload-istioctl
+++ b/bin/upload-istioctl
@@ -8,7 +8,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 DIR_NAME="$(basename ${ROOT})"
 BIN_DIR='.'
 BUCKET_PATH=''


### PR DESCRIPTION
Fixes breakage of upload-istioctl when the build directory is a symlink.

**Release note**:
```release-note
Fix failure on cross-compiled istioctl builds when path contains a symlink
```
