### PR TITLE
build should depend on kubeconfig.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ fmt:
 	@bin/fmt.sh
 
 .PHONY: build
-build:	
+build: kubeconfig
+	@bin/install-prereqs.sh
 	@bazel build //...
 
 .PHONY: clean
@@ -52,5 +53,5 @@ racetest:
 	@bazel test --features=race //...
 
 kubeconfig:
-	@ln -s ~/.kube/config platform/kube/
+	@bin/kubeconfig.sh
 

--- a/bin/kubeconfig.sh
+++ b/bin/kubeconfig.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -f platform/kube/config ]; then
+  ln -s ~/.kube/config platform/kube/
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
`make build` will be failed if do not run `make setup`. This PR enabled `make setup` first before `make build`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

/cc @rshriram 