### PR TITLE
fix format of the local tag in bin/push-docker

### DIFF
--- a/bin/push-docker
+++ b/bin/push-docker
@@ -35,7 +35,7 @@ function docker_push() {
 }
 
 hubs="gcr.io/istio-testing"
-local_tag=$(whoami)_$(date +%y%m%d_%h%m%s)
+local_tag=$(whoami)_$(date +%y%m%d_%H%M%S)
 tags="${local_tag}"
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
The current local tag format is `$(whoami)_$(date +%y%m%d_%h%m%s)`.
It seems the intention was to have the date as year, month, day, hour, minute, second. However, %h is a shortened month name like Aug, and %m is month. This way, month appears three time in the tag, for no reason. The correct format is %H for hours, %M for minutes and %S for seconds.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```