### PR TITLE
[WIP] add egress forward proxy docker image to build

### DIFF
--- a/bin/push-docker
+++ b/bin/push-docker
@@ -62,7 +62,7 @@ IFS=',' read -ra tags <<< "${tags}"
 IFS=',' read -ra hubs <<< "${hubs}"
 
 pushd docker
-  for image in app proxy proxy_init proxy_debug pilot sidecar_initializer; do
+  for image in app proxy proxy_init proxy_debug pilot sidecar_initializer egress_forward_proxy; do
     local_image="${image}:${local_tag}"
     docker build -q -f "Dockerfile.${image}" -t "${local_image}" .
     for tag in ${tags[@]}; do

--- a/docker/Dockerfile.egress_forward_proxy
+++ b/docker/Dockerfile.egress_forward_proxy
@@ -1,0 +1,2 @@
+FROM nginx
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,73 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+	gzip_disable "msie6";
+
+	##
+	# Virtual Host Configs
+	##
+
+	# http forward proxy
+	server {
+               listen       127.0.0.1:8080;
+
+	        location / {
+	            resolver 8.8.8.8;
+		    proxy_pass http://$http_host$uri$is_args$args;
+        	 }
+        }
+
+	#forward proxy with TLS origination
+	server {
+               listen       127.0.0.1:8081;
+
+	        location / {
+	            resolver 8.8.8.8;
+		    proxy_pass https://$http_host$uri$is_args$args;
+        	 }
+        }
+}


### PR DESCRIPTION
Using nginx, a temporary solution until forward proxy functionality is implemented in envoy.

**What this PR does / why we need it**:
Adds a forward proxy docker image, to be added to egress container, as an additional pod. Forward proxy functionality is needed to add support to egress-rules, to direct traffic thru egress.

Note: The original_dst cluster will not help here since egress's envoy does not receives traffic by iptables.

**Which issue this PR fixes** 

Related to issue https://github.com/istio/istio/issues/552

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```