### PR TITLE
revert GrpcEcho -> Echo

### DIFF
--- a/test/client/client.go
+++ b/test/client/client.go
@@ -155,12 +155,12 @@ func makeWebSocketRequest(client *websocket.Dialer) func(int) func() error {
 	}
 }
 
-func makeGRPCRequest(client pb.GrpcEchoTestServiceClient) func(int) func() error {
+func makeGRPCRequest(client pb.EchoTestServiceClient) func(int) func() error {
 	return func(i int) func() error {
 		return func() error {
-			req := &pb.GrpcEchoRequest{Message: fmt.Sprintf("request #%d", i)}
+			req := &pb.EchoRequest{Message: fmt.Sprintf("request #%d", i)}
 			log.Printf("[%d] grpcecho.Echo(%v)\n", i, req)
-			resp, err := client.GrpcEcho(context.Background(), req)
+			resp, err := client.Echo(context.Background(), req)
 			if err != nil {
 				return err
 			}
@@ -230,7 +230,7 @@ func main() {
 				log.Println(err)
 			}
 		}()
-		client := pb.NewGrpcEchoTestServiceClient(conn)
+		client := pb.NewEchoTestServiceClient(conn)
 		f = makeGRPCRequest(client)
 	} else if strings.HasPrefix(url, "ws://") || strings.HasPrefix(url, "wss://") {
 		/* #nosec */

--- a/test/grpcecho/echo.proto
+++ b/test/grpcecho/echo.proto
@@ -16,14 +16,14 @@ syntax = "proto3";
 
 package grpecho;
 
-service GrpcEchoTestService {
-  rpc GrpcEcho(GrpcEchoRequest) returns (GrpcEchoResponse);
+service EchoTestService {
+  rpc Echo(EchoRequest) returns (EchoResponse);
 }
 
-message GrpcEchoRequest {
+message EchoRequest {
   string message = 1;
 }
 
-message GrpcEchoResponse {
+message EchoResponse {
   string message = 1;
 }

--- a/test/grpcecho/echo.proto
+++ b/test/grpcecho/echo.proto
@@ -16,6 +16,9 @@ syntax = "proto3";
 
 package grpecho;
 
+// DO NOT CHANGE THIS NAME. The test system will fail in unpredictable ways
+// because something (most probably Bazel) is caching the generated pb.go
+// files and refuses to flush the cache, making every PR to pilot fail.
 service EchoTestService {
   rpc Echo(EchoRequest) returns (EchoResponse);
 }

--- a/test/server/echo.go
+++ b/test/server/echo.go
@@ -129,7 +129,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h handler) GrpcEcho(ctx context.Context, req *pb.GrpcEchoRequest) (*pb.GrpcEchoResponse, error) {
+func (h handler) Echo(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	body := bytes.Buffer{}
 	md, ok := metadata.FromContext(ctx)
 	if ok {
@@ -140,7 +140,7 @@ func (h handler) GrpcEcho(ctx context.Context, req *pb.GrpcEchoRequest) (*pb.Grp
 	body.WriteString("ServiceVersion=" + version + "\n")
 	body.WriteString("ServicePort=" + strconv.Itoa(h.port) + "\n")
 	body.WriteString("Echo=" + req.GetMessage())
-	return &pb.GrpcEchoResponse{Message: body.String()}, nil
+	return &pb.EchoResponse{Message: body.String()}, nil
 }
 
 func (h handler) WebSocketEcho(w http.ResponseWriter, r *http.Request) {
@@ -201,7 +201,7 @@ func runGRPC(port int) {
 	} else {
 		grpcServer = grpc.NewServer()
 	}
-	pb.RegisterGrpcEchoTestServiceServer(grpcServer, &h)
+	pb.RegisterEchoTestServiceServer(grpcServer, &h)
 	if err = grpcServer.Serve(lis); err != nil {
 		log.Println(err.Error())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert renaming of Echo gRPC service to GrpcEcho service (as some piece of s**t is caching old pb.go files and refusing to flush the cache).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
