### PR TITLE
Customize service cluster

### DIFF
--- a/cmd/pilot-agent/BUILD
+++ b/cmd/pilot-agent/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//proxy/envoy:go_default_library",
         "//tools/version:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/cmd/pilot-agent/main.go
+++ b/cmd/pilot-agent/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/golang/glog"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 
 	"istio.io/pilot/cmd"
@@ -31,6 +32,7 @@ import (
 
 var (
 	configpath      string
+	binarypath      string
 	meshconfig      string
 	servicecluster  string
 	role            proxy.Node
@@ -62,6 +64,10 @@ var (
 			glog.V(2).Infof("version %s", version.Line())
 			glog.V(2).Infof("mesh configuration %#v", mesh)
 
+			if err := os.MkdirAll(configpath, 0700); err != nil {
+				return multierror.Prefix(err, "failed to create directory for proxy configuration")
+			}
+
 			// set values from registry platform
 			if role.IPAddress == "" {
 				if serviceregistry == platform.KubernetesRegistry || serviceregistry == "" {
@@ -89,10 +95,13 @@ var (
 				} else if serviceregistry == platform.ConsulRegistry {
 					role.Domain = "service.consul"
 				}
-
 			}
 
-			watcher, err := envoy.NewWatcher(mesh, role, servicecluster, configpath)
+			glog.V(2).Infof("proxy role: %#v", role)
+
+			envoyProxy := envoy.MakeProxy(mesh, servicecluster, role.ServiceNode(), configpath, binarypath)
+			agent := proxy.NewAgent(envoyProxy, proxy.DefaultRetry)
+			watcher, err := envoy.NewWatcher(mesh, agent, role)
 			if err != nil {
 				return err
 			}
@@ -117,6 +126,8 @@ func init() {
 		"File name for Istio mesh configuration")
 	proxyCmd.PersistentFlags().StringVar(&configpath, "configpath", "/etc/istio/proxy",
 		"Path to generated proxy configuration directory")
+	proxyCmd.PersistentFlags().StringVar(&binarypath, "binarypath", "/usr/local/bin/envoy",
+		"Path to Envoy binary")
 	proxyCmd.PersistentFlags().StringVar(&role.IPAddress, "ip", "",
 		"Proxy IP address. If not provided uses ${INSTANCE_IP} environment variable.")
 	proxyCmd.PersistentFlags().StringVar(&role.ID, "id", "",

--- a/cmd/pilot-agent/main.go
+++ b/cmd/pilot-agent/main.go
@@ -64,7 +64,7 @@ var (
 			glog.V(2).Infof("version %s", version.Line())
 			glog.V(2).Infof("mesh configuration %#v", mesh)
 
-			if err := os.MkdirAll(configpath, 0700); err != nil {
+			if err = os.MkdirAll(configpath, 0700); err != nil {
 				return multierror.Prefix(err, "failed to create directory for proxy configuration")
 			}
 

--- a/cmd/pilot-agent/main.go
+++ b/cmd/pilot-agent/main.go
@@ -62,10 +62,6 @@ var (
 			glog.V(2).Infof("version %s", version.Line())
 			glog.V(2).Infof("mesh configuration %#v", mesh)
 
-			if servicecluster == "" {
-				servicecluster = mesh.IstioServiceCluster
-			}
-
 			// set values from registry platform
 			if role.IPAddress == "" {
 				if serviceregistry == platform.KubernetesRegistry || serviceregistry == "" {
@@ -127,8 +123,8 @@ func init() {
 		"Proxy unique ID. If not provided uses ${POD_NAME}.${POD_NAMESPACE} from environment variables")
 	proxyCmd.PersistentFlags().StringVar(&role.Domain, "domain", "",
 		"DNS domain suffix. If not provided uses ${POD_NAMESPACE}.svc.cluster.local")
-	proxyCmd.PersistentFlags().StringVar(&servicecluster, "servicecluster", "",
-		"Service cluster value to override mesh service cluster")
+	proxyCmd.PersistentFlags().StringVar(&servicecluster, "servicecluster", "istio-proxy",
+		"Service cluster value")
 
 	cmd.AddFlags(rootCmd)
 

--- a/cmd/pilot-agent/main.go
+++ b/cmd/pilot-agent/main.go
@@ -32,6 +32,7 @@ import (
 var (
 	configpath      string
 	meshconfig      string
+	servicecluster  string
 	role            proxy.Node
 	serviceregistry platform.ServiceRegistry
 
@@ -60,6 +61,10 @@ var (
 
 			glog.V(2).Infof("version %s", version.Line())
 			glog.V(2).Infof("mesh configuration %#v", mesh)
+
+			if servicecluster == "" {
+				servicecluster = mesh.IstioServiceCluster
+			}
 
 			// set values from registry platform
 			if role.IPAddress == "" {
@@ -91,7 +96,7 @@ var (
 
 			}
 
-			watcher, err := envoy.NewWatcher(mesh, role, configpath)
+			watcher, err := envoy.NewWatcher(mesh, role, servicecluster, configpath)
 			if err != nil {
 				return err
 			}
@@ -122,6 +127,8 @@ func init() {
 		"Proxy unique ID. If not provided uses ${POD_NAME}.${POD_NAMESPACE} from environment variables")
 	proxyCmd.PersistentFlags().StringVar(&role.Domain, "domain", "",
 		"DNS domain suffix. If not provided uses ${POD_NAMESPACE}.svc.cluster.local")
+	proxyCmd.PersistentFlags().StringVar(&servicecluster, "servicecluster", "",
+		"Service cluster value to override mesh service cluster")
 
 	cmd.AddFlags(rootCmd)
 

--- a/model/BUILD
+++ b/model/BUILD
@@ -34,7 +34,6 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//model/test:go_default_library",
-        "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",

--- a/proxy/agent.go
+++ b/proxy/agent.go
@@ -87,8 +87,8 @@ const (
 // NewAgent creates a new proxy agent for the proxy start-up and clean-up functions.
 func NewAgent(proxy Proxy, retry Retry) Agent {
 	return &agent{
-		proxy:    &proxy,
-		retry:    &retry,
+		proxy:    proxy,
+		retry:    retry,
 		epochs:   make(map[int]interface{}),
 		configCh: make(chan interface{}),
 		statusCh: make(chan exitStatus),
@@ -113,24 +113,24 @@ type Retry struct {
 }
 
 // Proxy defines command interface for a proxy
-type Proxy struct {
+type Proxy interface {
 	// Run command for a config, epoch, and abort channel
-	Run func(interface{}, int, <-chan error) error
+	Run(interface{}, int, <-chan error) error
 
 	// Cleanup command for an epoch
-	Cleanup func(int)
+	Cleanup(int)
 
 	// Panic command is invoked with the desired config when all retries to
 	// start the proxy fail just before the agent terminating
-	Panic func(interface{})
+	Panic(interface{})
 }
 
 type agent struct {
 	// proxy commands
-	proxy *Proxy
+	proxy Proxy
 
 	// retry configuration
-	retry *Retry
+	retry Retry
 
 	// desired configuration state
 	desiredConfig interface{}
@@ -224,9 +224,7 @@ func (a *agent) Run(ctx context.Context) {
 					glog.V(2).Infof("Updated retry delay to %v, budget to %d", delayDuration, a.retry.budget)
 				} else {
 					glog.Error("Permanent error: budget exhausted trying to fulfill the desired configuration")
-					if a.proxy.Panic != nil {
-						a.proxy.Panic(a.desiredConfig)
-					}
+					a.proxy.Panic(a.desiredConfig)
 					return
 				}
 			}

--- a/proxy/envoy/watcher_test.go
+++ b/proxy/envoy/watcher_test.go
@@ -23,14 +23,14 @@ import (
 
 func TestEnvoyArgs(t *testing.T) {
 	mesh := proxy.DefaultMeshConfig()
-	got := envoyArgs("test.json", 5, &mesh, "my-proxy")
+	got := envoyArgs("test.json", 5, &mesh, "my-cluster", "my-node")
 	want := []string{
 		"-c", "test.json",
 		"--restart-epoch", "5",
 		"--drain-time-s", "2",
 		"--parent-shutdown-time-s", "3",
-		"--service-cluster", mesh.IstioServiceCluster,
-		"--service-node", "my-proxy",
+		"--service-cluster", "my-cluster",
+		"--service-node", "my-node",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("envoyArgs() => got %v, want %v", got, want)

--- a/proxy/envoy/watcher_test.go
+++ b/proxy/envoy/watcher_test.go
@@ -23,7 +23,12 @@ import (
 
 func TestEnvoyArgs(t *testing.T) {
 	mesh := proxy.DefaultMeshConfig()
-	got := envoyArgs("test.json", 5, &mesh, "my-cluster", "my-node")
+	test := envoy{
+		mesh:           &mesh,
+		serviceCluster: "my-cluster",
+		serviceNode:    "my-node",
+	}
+	got := test.args("test.json", 5)
 	want := []string{
 		"-c", "test.json",
 		"--restart-epoch", "5",

--- a/test/mock/BUILD
+++ b/test/mock/BUILD
@@ -20,9 +20,6 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = [
-        "service_test.go",
-    ],
+    srcs = ["service_test.go"],
     library = ":go_default_library",
-    deps = ["//model:go_default_library"],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
add a flag to override "istio-proxy" as service cluster

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Exposes Envoy service-cluster and binarypath options to the proxy agent, allowing customizations.
```
