### PR TITLE
Fix to allow kubectl list CRDs

### DIFF
--- a/adapter/config/crd/controller.go
+++ b/adapter/config/crd/controller.go
@@ -72,7 +72,7 @@ func (c *controller) addInformer(schema model.ProtoSchema, namespace string, res
 			result = knownTypes[schema.Type].collection.DeepCopyObject()
 			err = c.client.dynamic.Get().
 				Namespace(namespace).
-				Resource(schema.Plural).
+				Resource(resourceName(schema.Plural)).
 				VersionedParams(&opts, meta_v1.ParameterCodec).
 				Do().
 				Into(result)
@@ -82,7 +82,7 @@ func (c *controller) addInformer(schema model.ProtoSchema, namespace string, res
 			return c.client.dynamic.Get().
 				Prefix("watch").
 				Namespace(namespace).
-				Resource(schema.Plural).
+				Resource(resourceName(schema.Plural)).
 				VersionedParams(&opts, meta_v1.ParameterCodec).
 				Watch()
 		})

--- a/adapter/config/crd/conversion.go
+++ b/adapter/config/crd/conversion.go
@@ -61,7 +61,13 @@ func convertConfig(schema model.ProtoSchema, config model.Config) (IstioObject, 
 	return out, nil
 }
 
-// camelCaseToKabobCase converts "my-name" to "MyName"
+// resourceName converts "my-name" to "myname".
+// This is needed by k8s API server as dashes prevent kubectl from accessing CRDs
+func resourceName(s string) string {
+	return strings.Replace(s, "-", "", -1)
+}
+
+// kabobCaseToCamelCase converts "my-name" to "MyName"
 func kabobCaseToCamelCase(s string) string {
 	words := strings.Split(s, "-")
 	out := ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes CRD name from `route-rules.config.istio.io` to `routerules.config.istio.io`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1107 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enable `kubectl get routerules` in place of `istioctl`.
```
