### PR TITLE
Update the CA docker image used for e2e test

### DIFF
--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -60,7 +60,7 @@ const (
 	// caImage specifies the default istio-ca docker image used for e2e testing *update manually*
 	caImage = "gcr.io/istio-testing/istio-ca:2baec6baacecbd516ea0880573b6fc3cd5736739"
 
-	// miserImage specifies the default mixer docker image used for e2e testing *update manually*
+	// mixerImage specifies the default mixer docker image used for e2e testing *update manually*
 	mixerImage = "gcr.io/istio-testing/mixer:49e721e15d481cd5d92d9a2b30b5e8fcdcafdb63"
 
 	// retry budget

--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -57,10 +57,10 @@ var (
 )
 
 const (
-	// CA image tag is the short SHA *update manually*
-	caTag = "689b447"
+	// caImage specifies the default istio-ca docker image used for e2e testing *update manually*
+	caImage = "gcr.io/istio-testing/istio-ca:2baec6baacecbd516ea0880573b6fc3cd5736739"
 
-	// Mixer image tag is the short SHA *update manually*
+	// miserImage specifies the default mixer docker image used for e2e testing *update manually*
 	mixerImage = "gcr.io/istio-testing/mixer:49e721e15d481cd5d92d9a2b30b5e8fcdcafdb63"
 
 	// retry budget
@@ -70,10 +70,8 @@ const (
 func init() {
 	flag.StringVar(&params.Hub, "hub", "gcr.io/istio-testing", "Docker hub")
 	flag.StringVar(&params.Tag, "tag", "", "Docker tag")
-	flag.StringVar(&params.CaImage, "ca", "gcr.io/istio-testing/istio-ca:"+caTag,
-		"CA Docker image")
-	flag.StringVar(&params.MixerImage, "mixer", mixerImage,
-		"Mixer Docker image")
+	flag.StringVar(&params.CaImage, "ca", caImage, "CA Docker image")
+	flag.StringVar(&params.MixerImage, "mixer", mixerImage, "Mixer Docker image")
 	flag.StringVar(&params.IstioNamespace, "ns", "",
 		"Namespace in which to install Istio components (empty to create/delete temporary one)")
 	flag.StringVar(&params.Namespace, "n", "",


### PR DESCRIPTION
Also make the `--mixer` and `--ca` CLI options consistent. Previously
`--mixer` takes the full docker image URI but `--ca` only accepts an
image tag. After this PR, both options take the full docker image URI.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
/cc @andraxylia 
/cc @wattli 
/cc @kyessenov 
