### PR TITLE
Fix the bug that when no service account is specified in annotation, empty service accounts are returned.

### DIFF
--- a/platform/kube/conversion.go
+++ b/platform/kube/conversion.go
@@ -83,11 +83,15 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 
 	serviceaccounts := make([]string, 0)
 	if svc.Annotations != nil {
-		for _, csa := range strings.Split(svc.Annotations[CanonicalServiceAccountsOnVMAnnotation], ",") {
-			serviceaccounts = append(serviceaccounts, canonicalToIstioServiceAccount(csa))
+		if svc.Annotations[CanonicalServiceAccountsOnVMAnnotation] != "" {
+			for _, csa := range strings.Split(svc.Annotations[CanonicalServiceAccountsOnVMAnnotation], ",") {
+				serviceaccounts = append(serviceaccounts, canonicalToIstioServiceAccount(csa))
+			}
 		}
-		for _, ksa := range strings.Split(svc.Annotations[KubeServiceAccountsOnVMAnnotation], ",") {
-			serviceaccounts = append(serviceaccounts, kubeToIstioServiceAccount(ksa, svc.Namespace, domainSuffix))
+		if svc.Annotations[KubeServiceAccountsOnVMAnnotation] != "" {
+			for _, ksa := range strings.Split(svc.Annotations[KubeServiceAccountsOnVMAnnotation], ",") {
+				serviceaccounts = append(serviceaccounts, kubeToIstioServiceAccount(ksa, svc.Namespace, domainSuffix))
+			}
 		}
 	}
 	sort.Sort(sort.StringSlice(serviceaccounts))

--- a/platform/kube/conversion_test.go
+++ b/platform/kube/conversion_test.go
@@ -166,7 +166,7 @@ func TestServiceConversionWithEmptyServiceAccountsAnnotation(t *testing.T) {
 	}
 
 	sa := service.ServiceAccounts
-	if sa != nil && len(sa) != 0 {
+	if len(sa) != 0 {
 		t.Errorf("number of service accounts is incorrect: %d, expected 0", len(sa))
 	}
 }

--- a/platform/kube/conversion_test.go
+++ b/platform/kube/conversion_test.go
@@ -131,6 +131,46 @@ func TestServiceConversion(t *testing.T) {
 	}
 }
 
+func TestServiceConversionWithEmptyServiceAccountsAnnotation(t *testing.T) {
+	serviceName := "service1"
+	namespace := "default"
+
+	ip := "10.0.0.1"
+
+	localSvc := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        serviceName,
+			Namespace:   namespace,
+			Annotations: map[string]string{},
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: ip,
+			Ports: []v1.ServicePort{
+				{
+					Name:     "http",
+					Port:     8080,
+					Protocol: v1.ProtocolTCP,
+				},
+				{
+					Name:     "https",
+					Protocol: v1.ProtocolTCP,
+					Port:     443,
+				},
+			},
+		},
+	}
+
+	service := convertService(localSvc, domainSuffix)
+	if service == nil {
+		t.Errorf("could not convert service")
+	}
+
+	sa := service.ServiceAccounts
+	if sa != nil && len(sa) != 0 {
+		t.Errorf("number of service accounts is incorrect: %d, expected 0", len(sa))
+	}
+}
+
 func TestExternalServiceConversion(t *testing.T) {
 	serviceName := "service1"
 	namespace := "default"


### PR DESCRIPTION
```
NONE
```
