### PR TITLE
Script to build using plain go from MAC (no bazel needed)

### DIFF
--- a/bin/gobuild-and-push-nobazel
+++ b/bin/gobuild-and-push-nobazel
@@ -39,6 +39,8 @@ done
 export GOOS=linux
 export GOARCH=amd64
 
+echo "Make sure to run 'dep ensure' to pull vendor dependencies."
+
 go build ./cmd/pilot-agent
 go build ./cmd/pilot-discovery
 go build ./test/server

--- a/bin/gobuild-and-push-nobazel
+++ b/bin/gobuild-and-push-nobazel
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Copyright 2017 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+# This script creates a base image for the init image that includes iptables.
+#
+
+set -ex
+set -o errexit
+set -o nounset
+set -o pipefail
+
+hub="gcr.io/istio-testing"
+tag=$(whoami)_$(date +%y%m%d_%h%m%s)
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -tag) tag="$2"; shift ;;
+        -hub) hub="$2"; shift ;;
+        *) ;;
+    esac
+    shift
+done
+
+export GOOS=linux
+export GOARCH=amd64
+
+go build ./cmd/pilot-agent
+go build ./cmd/pilot-discovery
+go build ./test/server
+go build ./test/client
+
+# Collect artifacts for pushing
+cp -f  client docker/client
+cp -f  server docker/server
+cp -f  pilot-agent docker/pilot-agent
+cp -f  pilot-discovery docker/pilot-discovery
+
+# Build and push images
+if [[ "$hub" =~ ^gcr\.io ]]; then
+  gcloud docker --authorize-only
+fi
+
+pushd docker
+  for image in app proxy proxy_init proxy_debug pilot; do
+    docker build -f "Dockerfile.${image}" -t "$hub/$image:$tag" .
+    docker push "$hub/$image:$tag"
+  done
+popd
+
+echo Pushed images to $hub with tag $tag


### PR DESCRIPTION
**What this PR does / why we need it**:

It helps a lot when you develop from Mac and hit issues with Bazel.

Make sure you run dep ensure first to bring vendor dependencies.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
