### PR TITLE
make the virtual host's name as the key of the egress rule

### DIFF
--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -634,8 +634,8 @@ func appendPortToDomains(domains []string, port int) []string {
 	return domainsWithPorts
 }
 
-func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule, mesh *proxyconfig.ProxyMeshConfig,
-	port *model.Port) *VirtualHost {
+func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule, ruleKey string,
+	mesh *proxyconfig.ProxyMeshConfig, port *model.Port) *VirtualHost {
 	var externalTrafficCluster *Cluster
 
 	protocolToHandle := port.Protocol
@@ -664,7 +664,7 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule, mesh 
 	externalTrafficRoute := buildDefaultRoute(externalTrafficCluster)
 
 	return &VirtualHost{
-		Name:    rule.Domains[0] + "-" + strconv.Itoa(port.Port),
+		Name:    ruleKey + ":" + strconv.Itoa(port.Port),
 		Domains: appendPortToDomains(rule.Domains, port.Port),
 		Routes:  []*HTTPRoute{externalTrafficRoute},
 	}
@@ -672,7 +672,7 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule, mesh 
 
 func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.ProxyMeshConfig, egressRules map[string]*proxyconfig.EgressRule,
 	httpConfigs HTTPRouteConfigs) HTTPRouteConfigs {
-	for _, rule := range egressRules {
+	for key, rule := range egressRules {
 		if len(rule.Domains) < 1 {
 			continue
 		}
@@ -686,7 +686,7 @@ func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.ProxyMeshConfig, egressR
 			modelPort := &model.Port{Name: "external-traffic-port", Port: intPort, Protocol: protocol}
 			httpConfig := httpConfigs.EnsurePort(intPort)
 			httpConfig.VirtualHosts = append(httpConfig.VirtualHosts,
-				buildEgressFromSidecarVirtualHostOnPort(rule, mesh, modelPort))
+				buildEgressFromSidecarVirtualHostOnPort(rule, key, mesh, modelPort))
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It improves the debuggabilty of egress-rule's virtual hosts

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
