### PR TITLE
Reject egress rules that conflict on some domain

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -480,12 +480,17 @@ func (store *istioConfigStore) Policy(instances []*ServiceInstance, destination 
 // According to Envoy's virtual host specification, no virtual hosts can share the same domain.
 // The following code rejects conflicting rules deterministically, by a lexicographical order -
 // a rule with a smaller key lexicographically wins.
+// Here the key of the rule is the key of the Istio configuration objects - see
+// `func (meta *ConfigMeta) Key() string`
 func RejectConflictingEgressRules(egressRules map[string]*proxyconfig.EgressRule) ( // long line split
 	map[string]*proxyconfig.EgressRule, error) {
 	filteredEgressRules := make(map[string]*proxyconfig.EgressRule)
 	var errs error
 
 	var keys []string
+
+	// the key here is the key of the Istio configuration objects - see
+	// `func (meta *ConfigMeta) Key() string`
 	for key := range egressRules {
 		keys = append(keys, key)
 	}

--- a/model/config.go
+++ b/model/config.go
@@ -484,7 +484,7 @@ func RejectConflictingEgressRules(egressRules map[string]*proxyconfig.EgressRule
 	var errs error
 
 	var keys []string
-	for key, _ := range egressRules {
+	for key := range egressRules {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)

--- a/model/config.go
+++ b/model/config.go
@@ -479,7 +479,8 @@ func (store *istioConfigStore) Policy(instances []*ServiceInstance, destination 
 // According to Envoy's virtual host specification, no virtual hosts can share the same domain.
 // The following code rejects conflicting rules determenistically, by a lexicographical order - a rule with
 // a smaller name lexicographically wins.
-func RejectConflictingEgressRules(egressRules map[string]*proxyconfig.EgressRule) (map[string]*proxyconfig.EgressRule, error) {
+func RejectConflictingEgressRules(egressRules map[string]*proxyconfig.EgressRule) ( // long line split
+	map[string]*proxyconfig.EgressRule, error) {
 	filteredEgressRules := make(map[string]*proxyconfig.EgressRule)
 	var errs error
 

--- a/model/config.go
+++ b/model/config.go
@@ -475,10 +475,11 @@ func (store *istioConfigStore) Policy(instances []*ServiceInstance, destination 
 	return out
 }
 
-// RejectConflictingEgressRules rejects rules that have a domain which same to domains of some other rule.
+// RejectConflictingEgressRules rejects rules that have a domain which is equal to
+// a domain of some other rule.
 // According to Envoy's virtual host specification, no virtual hosts can share the same domain.
-// The following code rejects conflicting rules determenistically, by a lexicographical order - a rule with
-// a smaller name lexicographically wins.
+// The following code rejects conflicting rules deterministically, by a lexicographical order -
+// a rule with a smaller key lexicographically wins.
 func RejectConflictingEgressRules(egressRules map[string]*proxyconfig.EgressRule) ( // long line split
 	map[string]*proxyconfig.EgressRule, error) {
 	filteredEgressRules := make(map[string]*proxyconfig.EgressRule)

--- a/model/config.go
+++ b/model/config.go
@@ -475,7 +475,7 @@ func (store *istioConfigStore) Policy(instances []*ServiceInstance, destination 
 	return out
 }
 
-// this function rejects rules that have a domain which same to domains of some other rule.
+// RejectConflictingEgressRules rejects rules that have a domain which same to domains of some other rule.
 // According to Envoy's virtual host specification, no virtual hosts can share the same domain.
 // The following code rejects conflicting rules determenistically, by a lexicographical order - a rule with
 // a smaller name lexicographically wins.

--- a/model/config.go
+++ b/model/config.go
@@ -494,11 +494,11 @@ func RejectConflictingEgressRules(egressRules map[string]*proxyconfig.EgressRule
 		egressRule := egressRules[key]
 		conflictingRule := false
 		for _, domain := range egressRule.Domains {
-			keyOfAnEgressRuleWithTheSameDomain, conflictFound := domains[domain]
-			if conflictFound {
+			var keyOfAnEgressRuleWithTheSameDomain string
+			keyOfAnEgressRuleWithTheSameDomain, conflictingRule = domains[domain]
+			if conflictingRule {
 				errs = multierror.Append(errs, fmt.Errorf("rule %q conflicts with rule %q on domain %s, is rejected",
 					key, keyOfAnEgressRuleWithTheSameDomain, domain))
-				conflictingRule = true
 				break
 			}
 		}

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -541,6 +541,32 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 				},
 			},
 			valid: false},
+		{name: "a conflict in a domain, different ports and protocols",
+			in: map[string]*proxyconfig.EgressRule{"cnn2": {
+				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Ports: []*proxyconfig.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 443, Protocol: "https"},
+				},
+			},
+				"cnn1": {
+					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 8080, Protocol: "http2"},
+						{Port: 8081, Protocol: "grpc"},
+					},
+				},
+			},
+			out: map[string]*proxyconfig.EgressRule{
+				"cnn1": {
+					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 8080, Protocol: "http2"},
+						{Port: 8081, Protocol: "grpc"},
+					},
+				},
+			},
+			valid: false},
 		{name: "two conflicts, one rule rejected",
 			in: map[string]*proxyconfig.EgressRule{"cnn2": {
 				Domains: []string{"*cnn.com", "*.cnn.com"},

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -475,3 +475,156 @@ func TestPolicy(t *testing.T) {
 		t.Error("Policy() => expected no match for source-matched policy")
 	}
 }
+
+func TestRejectConflictingEgressRules(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    map[string]*proxyconfig.EgressRule
+		out   map[string]*proxyconfig.EgressRule
+		valid bool
+	}{
+		{name: "no conflicts",
+			in: map[string]*proxyconfig.EgressRule{"cnn": &proxyconfig.EgressRule{
+				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Ports: []*proxyconfig.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 443, Protocol: "https"},
+				},
+			},
+				"bbc": &proxyconfig.EgressRule{
+					Domains: []string{"*bbc.com", "*.bbc.com"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+			},
+			out: map[string]*proxyconfig.EgressRule{"cnn": &proxyconfig.EgressRule{
+				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Ports: []*proxyconfig.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 443, Protocol: "https"},
+				},
+			},
+				"bbc": &proxyconfig.EgressRule{
+					Domains: []string{"*bbc.com", "*.bbc.com"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+			},
+			valid: true},
+		{name: "a conflict in a domain",
+			in: map[string]*proxyconfig.EgressRule{"cnn2": &proxyconfig.EgressRule{
+				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Ports: []*proxyconfig.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 443, Protocol: "https"},
+				},
+			},
+				"cnn1": &proxyconfig.EgressRule{
+					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+			},
+			out: map[string]*proxyconfig.EgressRule{
+				"cnn1": &proxyconfig.EgressRule{
+					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+			},
+			valid: false},
+		{name: "two conflicts, removed one rule",
+			in: map[string]*proxyconfig.EgressRule{"cnn2": &proxyconfig.EgressRule{
+				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Ports: []*proxyconfig.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 443, Protocol: "https"},
+				},
+			},
+				"cnn1": &proxyconfig.EgressRule{
+					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+				"cnn3": &proxyconfig.EgressRule{
+					Domains: []string{"*.cnn.com", "edition.cnn.com"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+			},
+			out: map[string]*proxyconfig.EgressRule{
+				"cnn1": &proxyconfig.EgressRule{
+					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+				"cnn3": &proxyconfig.EgressRule{
+					Domains: []string{"*.cnn.com", "edition.cnn.com"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+			},
+			valid: false},
+		{name: "two conflicts, removed two rules",
+			in: map[string]*proxyconfig.EgressRule{"cnn2": &proxyconfig.EgressRule{
+				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Ports: []*proxyconfig.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 443, Protocol: "https"},
+				},
+			},
+				"cnn1": &proxyconfig.EgressRule{
+					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+				"cnn3": &proxyconfig.EgressRule{
+					Domains: []string{"*.cnn.de", "edition.cnn.com"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+			},
+			out: map[string]*proxyconfig.EgressRule{
+				"cnn1": &proxyconfig.EgressRule{
+					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Ports: []*proxyconfig.EgressRule_Port{
+						{Port: 80, Protocol: "http"},
+						{Port: 443, Protocol: "https"},
+					},
+				},
+			},
+			valid: false},
+	}
+
+	for _, c := range cases {
+		got, errs := model.RejectConflictingEgressRules(c.in)
+		if (errs == nil) != c.valid {
+			t.Errorf("RejectConflictingEgressRules failed on %s: got valid=%v but wanted valid=%v",
+				c.name, errs == nil, c.valid)
+		}
+		if !reflect.DeepEqual(got, c.out) {
+			t.Errorf("RejectConflictingEgressRules failed on %s: got=%v but wanted %v: %v",
+				c.name, got, c.in)
+		}
+	}
+}

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -541,7 +541,7 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 				},
 			},
 			valid: false},
-		{name: "two conflicts, removed one rule",
+		{name: "two conflicts, one rule rejected",
 			in: map[string]*proxyconfig.EgressRule{"cnn2": &proxyconfig.EgressRule{
 				Domains: []string{"*cnn.com", "*.cnn.com"},
 				Ports: []*proxyconfig.EgressRule_Port{
@@ -581,7 +581,7 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 				},
 			},
 			valid: false},
-		{name: "two conflicts, removed two rules",
+		{name: "two conflicts, two rules rejected",
 			in: map[string]*proxyconfig.EgressRule{"cnn2": &proxyconfig.EgressRule{
 				Domains: []string{"*cnn.com", "*.cnn.com"},
 				Ports: []*proxyconfig.EgressRule_Port{

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -484,14 +484,14 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 		valid bool
 	}{
 		{name: "no conflicts",
-			in: map[string]*proxyconfig.EgressRule{"cnn": &proxyconfig.EgressRule{
+			in: map[string]*proxyconfig.EgressRule{"cnn": {
 				Domains: []string{"*cnn.com", "*.cnn.com"},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
 				},
 			},
-				"bbc": &proxyconfig.EgressRule{
+				"bbc": {
 					Domains: []string{"*bbc.com", "*.bbc.com"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
@@ -499,14 +499,14 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 					},
 				},
 			},
-			out: map[string]*proxyconfig.EgressRule{"cnn": &proxyconfig.EgressRule{
+			out: map[string]*proxyconfig.EgressRule{"cnn": {
 				Domains: []string{"*cnn.com", "*.cnn.com"},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
 				},
 			},
-				"bbc": &proxyconfig.EgressRule{
+				"bbc": {
 					Domains: []string{"*bbc.com", "*.bbc.com"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
@@ -516,14 +516,14 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 			},
 			valid: true},
 		{name: "a conflict in a domain",
-			in: map[string]*proxyconfig.EgressRule{"cnn2": &proxyconfig.EgressRule{
+			in: map[string]*proxyconfig.EgressRule{"cnn2": {
 				Domains: []string{"*cnn.com", "*.cnn.com"},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
 				},
 			},
-				"cnn1": &proxyconfig.EgressRule{
+				"cnn1": {
 					Domains: []string{"*cnn.com", "*.cnn.de"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
@@ -532,7 +532,7 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 				},
 			},
 			out: map[string]*proxyconfig.EgressRule{
-				"cnn1": &proxyconfig.EgressRule{
+				"cnn1": {
 					Domains: []string{"*cnn.com", "*.cnn.de"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
@@ -542,21 +542,21 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 			},
 			valid: false},
 		{name: "two conflicts, one rule rejected",
-			in: map[string]*proxyconfig.EgressRule{"cnn2": &proxyconfig.EgressRule{
+			in: map[string]*proxyconfig.EgressRule{"cnn2": {
 				Domains: []string{"*cnn.com", "*.cnn.com"},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
 				},
 			},
-				"cnn1": &proxyconfig.EgressRule{
+				"cnn1": {
 					Domains: []string{"*cnn.com", "*.cnn.de"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
 						{Port: 443, Protocol: "https"},
 					},
 				},
-				"cnn3": &proxyconfig.EgressRule{
+				"cnn3": {
 					Domains: []string{"*.cnn.com", "edition.cnn.com"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
@@ -565,14 +565,14 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 				},
 			},
 			out: map[string]*proxyconfig.EgressRule{
-				"cnn1": &proxyconfig.EgressRule{
+				"cnn1": {
 					Domains: []string{"*cnn.com", "*.cnn.de"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
 						{Port: 443, Protocol: "https"},
 					},
 				},
-				"cnn3": &proxyconfig.EgressRule{
+				"cnn3": {
 					Domains: []string{"*.cnn.com", "edition.cnn.com"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
@@ -582,21 +582,21 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 			},
 			valid: false},
 		{name: "two conflicts, two rules rejected",
-			in: map[string]*proxyconfig.EgressRule{"cnn2": &proxyconfig.EgressRule{
+			in: map[string]*proxyconfig.EgressRule{"cnn2": {
 				Domains: []string{"*cnn.com", "*.cnn.com"},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
 				},
 			},
-				"cnn1": &proxyconfig.EgressRule{
+				"cnn1": {
 					Domains: []string{"*cnn.com", "*.cnn.de"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
 						{Port: 443, Protocol: "https"},
 					},
 				},
-				"cnn3": &proxyconfig.EgressRule{
+				"cnn3": {
 					Domains: []string{"*.cnn.de", "edition.cnn.com"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
@@ -605,7 +605,7 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 				},
 			},
 			out: map[string]*proxyconfig.EgressRule{
-				"cnn1": &proxyconfig.EgressRule{
+				"cnn1": {
 					Domains: []string{"*cnn.com", "*.cnn.de"},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -541,7 +541,7 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 				},
 			},
 			valid: false},
-		{name: "a conflict in a domain, different ports and protocols",
+		{name: "a conflict in a domain, different ports",
 			in: map[string]*proxyconfig.EgressRule{"cnn2": {
 				Domains: []string{"*cnn.com", "*.cnn.com"},
 				Ports: []*proxyconfig.EgressRule_Port{
@@ -552,21 +552,27 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 				"cnn1": {
 					Domains: []string{"*cnn.com", "*.cnn.de"},
 					Ports: []*proxyconfig.EgressRule_Port{
-						{Port: 8080, Protocol: "http2"},
-						{Port: 8081, Protocol: "grpc"},
+						{Port: 8080, Protocol: "http"},
+						{Port: 8081, Protocol: "https"},
 					},
 				},
 			},
-			out: map[string]*proxyconfig.EgressRule{
+			out: map[string]*proxyconfig.EgressRule{"cnn2": {
+				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Ports: []*proxyconfig.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 443, Protocol: "https"},
+				},
+			},
 				"cnn1": {
 					Domains: []string{"*cnn.com", "*.cnn.de"},
 					Ports: []*proxyconfig.EgressRule_Port{
-						{Port: 8080, Protocol: "http2"},
-						{Port: 8081, Protocol: "grpc"},
+						{Port: 8080, Protocol: "http"},
+						{Port: 8081, Protocol: "https"},
 					},
 				},
 			},
-			valid: false},
+			valid: true},
 		{name: "two conflicts, one rule rejected",
 			in: map[string]*proxyconfig.EgressRule{"cnn2": {
 				Domains: []string{"*cnn.com", "*.cnn.com"},

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -679,7 +679,6 @@ func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.ProxyMeshConfig, egressR
 		glog.Warningf("Rejected rules: %", errs)
 	}
 
-
 	for key, rule := range egressRules {
 		if len(rule.Domains) < 1 {
 			continue

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -672,6 +672,12 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule, mesh 
 
 func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.ProxyMeshConfig, egressRules map[string]*proxyconfig.EgressRule,
 	httpConfigs HTTPRouteConfigs) HTTPRouteConfigs {
+	egressRules, errs := model.RejectConflictingEgressRules(egressRules)
+
+	if errs != nil {
+		glog.Warningf("Rejected rules: %", errs)
+	}
+
 	for _, rule := range egressRules {
 		if len(rule.Domains) < 1 {
 			continue

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -676,7 +676,7 @@ func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.ProxyMeshConfig, egressR
 	egressRules, errs := model.RejectConflictingEgressRules(egressRules)
 
 	if errs != nil {
-		glog.Warningf("Rejected rules: %", errs)
+		glog.Warningf("Rejected rules: %v", errs)
 	}
 
 	for key, rule := range egressRules {

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -634,8 +634,8 @@ func appendPortToDomains(domains []string, port int) []string {
 	return domainsWithPorts
 }
 
-func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule, mesh *proxyconfig.ProxyMeshConfig,
-	port *model.Port) *VirtualHost {
+func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule, ruleKey string,
+	mesh *proxyconfig.ProxyMeshConfig, port *model.Port) *VirtualHost {
 	var externalTrafficCluster *Cluster
 
 	protocolToHandle := port.Protocol
@@ -664,7 +664,7 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule, mesh 
 	externalTrafficRoute := buildDefaultRoute(externalTrafficCluster)
 
 	return &VirtualHost{
-		Name:    rule.Domains[0] + "-" + strconv.Itoa(port.Port),
+		Name:    ruleKey + ":" + strconv.Itoa(port.Port),
 		Domains: appendPortToDomains(rule.Domains, port.Port),
 		Routes:  []*HTTPRoute{externalTrafficRoute},
 	}
@@ -672,13 +672,15 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule, mesh 
 
 func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.ProxyMeshConfig, egressRules map[string]*proxyconfig.EgressRule,
 	httpConfigs HTTPRouteConfigs) HTTPRouteConfigs {
+
 	egressRules, errs := model.RejectConflictingEgressRules(egressRules)
 
 	if errs != nil {
 		glog.Warningf("Rejected rules: %", errs)
 	}
 
-	for _, rule := range egressRules {
+
+	for key, rule := range egressRules {
 		if len(rule.Domains) < 1 {
 			continue
 		}
@@ -692,7 +694,7 @@ func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.ProxyMeshConfig, egressR
 			modelPort := &model.Port{Name: "external-traffic-port", Port: intPort, Protocol: protocol}
 			httpConfig := httpConfigs.EnsurePort(intPort)
 			httpConfig.VirtualHosts = append(httpConfig.VirtualHosts,
-				buildEgressFromSidecarVirtualHostOnPort(rule, mesh, modelPort))
+				buildEgressFromSidecarVirtualHostOnPort(rule, key, mesh, modelPort))
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent conflicting egress rules from causing envoy to crash.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1166


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
```