### PR TITLE
enable mongodb filter

### DIFF
--- a/cmd/pilot-discovery/main.go
+++ b/cmd/pilot-discovery/main.go
@@ -23,6 +23,8 @@ import (
 	"github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	proxyconfig "istio.io/api/proxy/v1/config"
 	"istio.io/pilot/adapter/config/aggregate"
 	"istio.io/pilot/adapter/config/crd"
@@ -35,7 +37,6 @@ import (
 	"istio.io/pilot/proxy"
 	"istio.io/pilot/proxy/envoy"
 	"istio.io/pilot/tools/version"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ConsulArgs store the args related to Consul configuration

--- a/model/service.go
+++ b/model/service.go
@@ -98,6 +98,8 @@ const (
 	// ProtocolUDP declares that the port uses UDP.
 	// Note that UDP protocol is not currently supported by the proxy.
 	ProtocolUDP Protocol = "UDP"
+	// ProtocolMONGO declares that the port carries mongoDB traffic
+	ProtocolMONGO Protocol = "MONGO"
 )
 
 // IsHTTP is true for protocols that use HTTP as transport protocol

--- a/platform/consul/conversion.go
+++ b/platform/consul/conversion.go
@@ -152,8 +152,12 @@ func convertProtocol(name string) model.Protocol {
 		return model.ProtocolHTTP2
 	case "https":
 		return model.ProtocolHTTPS
+	case "mongo":
+		return model.ProtocolMONGO
+	case "":
+		// fallthrough to default protocol
 	default:
-		return model.ProtocolHTTP
+		glog.Warningf("unsupported protocol value: %s", name)
 	}
-
+	return model.ProtocolTCP
 }

--- a/platform/eureka/conversion.go
+++ b/platform/eureka/conversion.go
@@ -130,6 +130,7 @@ const (
 	metadataHTTP2 = "http2"
 	metadataHTTPS = "https"
 	metadataGRPC  = "grpc"
+	metadataMONGO = "mongo"
 )
 
 func convertProtocol(md metadata) model.Protocol {
@@ -148,6 +149,8 @@ func convertProtocol(md metadata) model.Protocol {
 			return model.ProtocolHTTPS
 		case metadataGRPC:
 			return model.ProtocolGRPC
+		case metadataMONGO:
+			return model.ProtocolMONGO
 		case "":
 			// fallthrough to default protocol
 		default:

--- a/platform/eureka/conversion_test.go
+++ b/platform/eureka/conversion_test.go
@@ -197,6 +197,7 @@ func TestConvertProtocol(t *testing.T) {
 		{in: makeMetadata(metadataHTTP2), out: model.ProtocolHTTP2},
 		{in: makeMetadata(metadataHTTPS), out: model.ProtocolHTTPS},
 		{in: makeMetadata(metadataGRPC), out: model.ProtocolGRPC},
+		{in: makeMetadata(metadataMONGO), out: model.ProtocolMONGO},
 	}
 
 	for _, tt := range protocolTests {

--- a/platform/kube/conversion.go
+++ b/platform/kube/conversion.go
@@ -161,6 +161,8 @@ func convertProtocol(name string, proto v1.Protocol) model.Protocol {
 			out = model.ProtocolHTTP2
 		case "https":
 			out = model.ProtocolHTTPS
+		case "mongo":
+			out = model.ProtocolMONGO
 		}
 	}
 	return out

--- a/platform/kube/conversion_test.go
+++ b/platform/kube/conversion_test.go
@@ -44,6 +44,8 @@ var (
 		{"http2-test", v1.ProtocolTCP, model.ProtocolHTTP2},
 		{"grpc", v1.ProtocolTCP, model.ProtocolGRPC},
 		{"grpc-test", v1.ProtocolTCP, model.ProtocolGRPC},
+		{"mongo", v1.ProtocolTCP, model.ProtocolMONGO},
+		{"mongo-test", v1.ProtocolTCP, model.ProtocolMONGO},
 	}
 )
 

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -350,7 +350,30 @@ func applyInboundAuth(listener *Listener, mesh *proxyconfig.ProxyMeshConfig) {
 }
 
 // buildTCPListener constructs a listener for the TCP proxy
-func buildTCPListener(tcpConfig *TCPRouteConfig, ip string, port int) *Listener {
+// in addition, it enables mongo proxy filter based on the protocol
+func buildTCPListener(tcpConfig *TCPRouteConfig, ip string, port int, protocol model.Protocol) *Listener {
+	if protocol == model.ProtocolMONGO {
+		return &Listener{
+			Name:    fmt.Sprintf("mongo_%s_%d", ip, port),
+			Address: fmt.Sprintf("tcp://%s:%d", ip, port),
+			Filters: []*NetworkFilter{{
+				Type: both,
+				Name: MONGOProxyFilter,
+				Config: &MONGOProxyFilterConfig{
+					StatPrefix: "mongo",
+				},
+			},
+				{
+					Type: read,
+					Name: TCPProxyFilter,
+					Config: &TCPProxyFilterConfig{
+						StatPrefix:  "tcp",
+						RouteConfig: tcpConfig,
+					},
+				}},
+		}
+	}
+
 	return &Listener{
 		Name:    fmt.Sprintf("tcp_%s_%d", ip, port),
 		Address: fmt.Sprintf("tcp://%s:%d", ip, port),
@@ -430,7 +453,7 @@ func buildDestinationHTTPRoutes(service *model.Service,
 			return []*HTTPRoute{buildDefaultRoute(cluster)}
 		}
 
-	case model.ProtocolTCP:
+	case model.ProtocolTCP, model.ProtocolMONGO:
 		// handled by buildOutboundTCPListeners
 
 	default:
@@ -509,11 +532,11 @@ func buildOutboundTCPListeners(mesh *proxyconfig.ProxyMeshConfig, services []*mo
 		}
 		for _, servicePort := range service.Ports {
 			switch servicePort.Protocol {
-			case model.ProtocolTCP, model.ProtocolHTTPS:
+			case model.ProtocolTCP, model.ProtocolHTTPS, model.ProtocolMONGO:
 				cluster := buildOutboundCluster(service.Hostname, servicePort, nil)
 				route := buildTCPRoute(cluster, []string{service.Address})
 				config := &TCPRouteConfig{Routes: []*TCPRoute{route}}
-				listener := buildTCPListener(config, service.Address, servicePort.Port)
+				listener := buildTCPListener(config, service.Address, servicePort.Port, servicePort.Protocol)
 				tcpClusters = append(tcpClusters, cluster)
 				tcpListeners = append(tcpListeners, listener)
 			}
@@ -594,10 +617,10 @@ func buildInboundListeners(mesh *proxyconfig.ProxyMeshConfig, sidecar proxy.Node
 			listeners = append(listeners,
 				buildHTTPListener(mesh, sidecar, instances, config, endpoint.Address, endpoint.Port, "", false))
 
-		case model.ProtocolTCP, model.ProtocolHTTPS:
+		case model.ProtocolTCP, model.ProtocolHTTPS, model.ProtocolMONGO:
 			listener := buildTCPListener(&TCPRouteConfig{
 				Routes: []*TCPRoute{buildTCPRoute(cluster, []string{endpoint.Address})},
-			}, endpoint.Address, endpoint.Port)
+			}, endpoint.Address, endpoint.Port, protocol)
 
 			// set server-side mixer filter config
 			if mesh.MixerAddress != "" {
@@ -717,11 +740,12 @@ func buildMgmtPortListeners(mesh *proxyconfig.ProxyMeshConfig, managementPorts m
 	// assumes that inbound connections/requests are sent to the endpoint address
 	for _, mPort := range managementPorts {
 		switch mPort.Protocol {
-		case model.ProtocolHTTP, model.ProtocolHTTP2, model.ProtocolGRPC, model.ProtocolTCP, model.ProtocolHTTPS:
+		case model.ProtocolHTTP, model.ProtocolHTTP2, model.ProtocolGRPC, model.ProtocolTCP,
+			model.ProtocolHTTPS, model.ProtocolMONGO:
 			cluster := buildInboundCluster(mPort.Port, model.ProtocolTCP, mesh.ConnectTimeout)
 			listener := buildTCPListener(&TCPRouteConfig{
 				Routes: []*TCPRoute{buildTCPRoute(cluster, []string{managementIP})},
-			}, managementIP, mPort.Port)
+			}, managementIP, mPort.Port, model.ProtocolTCP)
 
 			clusters = append(clusters, cluster)
 			listeners = append(listeners, listener)

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -352,6 +352,9 @@ func applyInboundAuth(listener *Listener, mesh *proxyconfig.ProxyMeshConfig) {
 // buildTCPListener constructs a listener for the TCP proxy
 // in addition, it enables mongo proxy filter based on the protocol
 func buildTCPListener(tcpConfig *TCPRouteConfig, ip string, port int, protocol model.Protocol) *Listener {
+	// TODO: add a watcher for /var/lib/istio/mongo/certs
+	// if certs are found use, TLS or mTLS clusters for talking to MongoDB.
+	// User is responsible for mounting those certs in the pod.
 	if protocol == model.ProtocolMONGO {
 		return &Listener{
 			Name:    fmt.Sprintf("mongo_%s_%d", ip, port),

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -81,6 +81,9 @@ const (
 	// TCPProxyFilter is the name of the TCP Proxy network filter.
 	TCPProxyFilter = "tcp_proxy"
 
+	// MONGOProxyFilter is the name of the MONGO Proxy network filter.
+	MONGOProxyFilter = "mongo_proxy"
+
 	// WildcardAddress binds to all IP addresses
 	WildcardAddress = "0.0.0.0"
 
@@ -498,6 +501,14 @@ func (*TCPProxyFilterConfig) isNetworkFilterConfig() {}
 type TCPRouteConfig struct {
 	Routes []*TCPRoute `json:"routes"`
 }
+
+// MONGOProxyFilterConfig definition
+type MONGOProxyFilterConfig struct {
+	StatPrefix string `json:"stat_prefix"`
+	// TODO: support fault filter
+}
+
+func (*MONGOProxyFilterConfig) isNetworkFilterConfig() {}
 
 // NetworkFilter definition
 type NetworkFilter struct {

--- a/proxy/envoy/testdata/all-sds.json.golden
+++ b/proxy/envoy/testdata/all-sds.json.golden
@@ -39,6 +39,19 @@
    ]
   },
   {
+   "service-key": "hello.default.svc.cluster.local|mongo",
+   "hosts": [
+    {
+     "ip_address": "10.1.1.0",
+     "port": 1100
+    },
+    {
+     "ip_address": "10.1.1.1",
+     "port": 1100
+    }
+   ]
+  },
+  {
    "service-key": "world.default.svc.cluster.local|custom",
    "hosts": [
     {
@@ -74,6 +87,19 @@
     {
      "ip_address": "10.2.1.1",
      "port": 1081
+    }
+   ]
+  },
+  {
+   "service-key": "world.default.svc.cluster.local|mongo",
+   "hosts": [
+    {
+     "ip_address": "10.2.1.0",
+     "port": 1100
+    },
+    {
+     "ip_address": "10.2.1.1",
+     "port": 1100
     }
    ]
   }

--- a/proxy/envoy/testdata/cds-circuit-breaker.json.golden
+++ b/proxy/envoy/testdata/cds-circuit-breaker.json.golden
@@ -23,6 +23,17 @@
     ]
    },
    {
+    "name": "in.1100",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1100"
+     }
+    ]
+   },
+   {
     "name": "in.3333",
     "connect_timeout_ms": 1000,
     "type": "static",
@@ -54,6 +65,13 @@
       "url": "tcp://127.0.0.1:9999"
      }
     ]
+   },
+   {
+    "name": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+    "service_name": "world.default.svc.cluster.local|mongo",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
    },
    {
     "name": "out.242bc3028e0f3fe0682e6d972e167ab415b2321d",
@@ -100,6 +118,13 @@
      "base_ejection_time_ms": 15500,
      "max_ejection_percent": 100
     }
+   },
+   {
+    "name": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+    "service_name": "hello.default.svc.cluster.local|mongo",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
    },
    {
     "name": "out.81c187d71467b1608736c57bb0734f9ef9b68f7d",

--- a/proxy/envoy/testdata/cds-ssl-context.json.golden
+++ b/proxy/envoy/testdata/cds-ssl-context.json.golden
@@ -23,6 +23,17 @@
     ]
    },
    {
+    "name": "in.1100",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1100"
+     }
+    ]
+   },
+   {
     "name": "in.3333",
     "connect_timeout_ms": 1000,
     "type": "static",
@@ -56,6 +67,22 @@
     ]
    },
    {
+    "name": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+    "service_name": "world.default.svc.cluster.local|mongo",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin",
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "verify_subject_alt_name": [
+      "spiffe://cluster.local/ns/default/sa/serviceaccount1",
+      "spiffe://cluster.local/ns/default/sa/serviceaccount2"
+     ]
+    }
+   },
+   {
     "name": "out.242bc3028e0f3fe0682e6d972e167ab415b2321d",
     "connect_timeout_ms": 1000,
     "type": "strict_dns",
@@ -86,6 +113,19 @@
       "spiffe://cluster.local/ns/default/sa/serviceaccount1",
       "spiffe://cluster.local/ns/default/sa/serviceaccount2"
      ]
+    }
+   },
+   {
+    "name": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+    "service_name": "hello.default.svc.cluster.local|mongo",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin",
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "verify_subject_alt_name": []
     }
    },
    {

--- a/proxy/envoy/testdata/cds.json.golden
+++ b/proxy/envoy/testdata/cds.json.golden
@@ -23,6 +23,17 @@
     ]
    },
    {
+    "name": "in.1100",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1100"
+     }
+    ]
+   },
+   {
     "name": "in.3333",
     "connect_timeout_ms": 1000,
     "type": "static",
@@ -56,6 +67,13 @@
     ]
    },
    {
+    "name": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+    "service_name": "world.default.svc.cluster.local|mongo",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
     "name": "out.242bc3028e0f3fe0682e6d972e167ab415b2321d",
     "connect_timeout_ms": 1000,
     "type": "strict_dns",
@@ -69,6 +87,13 @@
    {
     "name": "out.5898aa4379cc19c8f1bb3b7915ee8e0e32ddc6a6",
     "service_name": "world.default.svc.cluster.local|custom",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+    "service_name": "hello.default.svc.cluster.local|mongo",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"

--- a/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
@@ -228,6 +228,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -365,6 +396,53 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.0",
+        "target.uid": "kubernetes://v0.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
+    },
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.0:3333",
     "name": "tcp_10.1.1.0_3333",
     "filters": [
@@ -476,6 +554,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v0-fault-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault-nomixer.json.golden
@@ -180,6 +180,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -263,6 +294,37 @@
         "routes": [
          {
           "cluster": "in.1090",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
           "destination_ip_list": [
            "10.1.1.0/32"
           ]
@@ -360,6 +422,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v0-fault.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault.json.golden
@@ -228,6 +228,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -353,6 +384,47 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.0",
+        "target.uid": "kubernetes://v0.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.0:3333",
     "name": "tcp_10.1.1.0_3333",
     "filters": [
@@ -458,6 +530,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v0-none-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none-auth.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -301,6 +332,53 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.0",
+        "target.uid": "kubernetes://v0.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
+    },
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.0:3333",
     "name": "tcp_10.1.1.0_3333",
     "filters": [
@@ -412,6 +490,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v0-none-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none-nomixer.json.golden
@@ -116,6 +116,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -199,6 +230,37 @@
         "routes": [
          {
           "cluster": "in.1090",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
           "destination_ip_list": [
            "10.1.1.0/32"
           ]
@@ -296,6 +358,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v0-none.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -289,6 +320,47 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.0",
+        "target.uid": "kubernetes://v0.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.0:3333",
     "name": "tcp_10.1.1.0_3333",
     "filters": [
@@ -394,6 +466,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -301,6 +332,53 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.0",
+        "target.uid": "kubernetes://v0.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
+    },
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.0:3333",
     "name": "tcp_10.1.1.0_3333",
     "filters": [
@@ -412,6 +490,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v0-weighted-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted-nomixer.json.golden
@@ -116,6 +116,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -199,6 +230,37 @@
         "routes": [
          {
           "cluster": "in.1090",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
           "destination_ip_list": [
            "10.1.1.0/32"
           ]
@@ -296,6 +358,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v0-weighted.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -289,6 +320,47 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.0",
+        "target.uid": "kubernetes://v0.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.0:3333",
     "name": "tcp_10.1.1.0_3333",
     "filters": [
@@ -394,6 +466,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -301,6 +332,53 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.1:1100",
+    "name": "mongo_10.1.1.1_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.1",
+        "target.uid": "kubernetes://v1.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
+    },
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.1:3333",
     "name": "tcp_10.1.1.1_3333",
     "filters": [
@@ -412,6 +490,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v1-fault-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault-nomixer.json.golden
@@ -116,6 +116,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -199,6 +230,37 @@
         "routes": [
          {
           "cluster": "in.1090",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.1:1100",
+    "name": "mongo_10.1.1.1_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
           "destination_ip_list": [
            "10.1.1.1/32"
           ]
@@ -296,6 +358,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v1-fault.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -289,6 +320,47 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.1:1100",
+    "name": "mongo_10.1.1.1_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.1",
+        "target.uid": "kubernetes://v1.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.1:3333",
     "name": "tcp_10.1.1.1_3333",
     "filters": [
@@ -394,6 +466,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v1-none-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none-auth.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -301,6 +332,53 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.1:1100",
+    "name": "mongo_10.1.1.1_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.1",
+        "target.uid": "kubernetes://v1.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
+    },
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.1:3333",
     "name": "tcp_10.1.1.1_3333",
     "filters": [
@@ -412,6 +490,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v1-none-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none-nomixer.json.golden
@@ -116,6 +116,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -199,6 +230,37 @@
         "routes": [
          {
           "cluster": "in.1090",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.1:1100",
+    "name": "mongo_10.1.1.1_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
           "destination_ip_list": [
            "10.1.1.1/32"
           ]
@@ -296,6 +358,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v1-none.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -289,6 +320,47 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.1:1100",
+    "name": "mongo_10.1.1.1_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.1",
+        "target.uid": "kubernetes://v1.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.1:3333",
     "name": "tcp_10.1.1.1_3333",
     "filters": [
@@ -394,6 +466,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -301,6 +332,53 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.1:1100",
+    "name": "mongo_10.1.1.1_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.1",
+        "target.uid": "kubernetes://v1.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
+    },
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.1:3333",
     "name": "tcp_10.1.1.1_3333",
     "filters": [
@@ -412,6 +490,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v1-weighted-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted-nomixer.json.golden
@@ -116,6 +116,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -199,6 +230,37 @@
         "routes": [
          {
           "cluster": "in.1090",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.1:1100",
+    "name": "mongo_10.1.1.1_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
           "destination_ip_list": [
            "10.1.1.1/32"
           ]
@@ -296,6 +358,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-v1-weighted.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -289,6 +320,47 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.1:1100",
+    "name": "mongo_10.1.1.1_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.1",
+        "target.uid": "kubernetes://v1.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.1:3333",
     "name": "tcp_10.1.1.1_3333",
     "filters": [
@@ -394,6 +466,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/proxy/envoy/testdata/lds-websocket.json.golden
+++ b/proxy/envoy/testdata/lds-websocket.json.golden
@@ -164,6 +164,37 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.0.0:90",
     "name": "tcp_10.1.0.0_90",
     "filters": [
@@ -298,6 +329,47 @@
     "bind_to_port": false
    },
    {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "target.ip": "10.1.1.0",
+        "target.uid": "kubernetes://v0.default"
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
     "address": "tcp://10.1.1.0:3333",
     "name": "tcp_10.1.1.0_3333",
     "filters": [
@@ -412,6 +484,37 @@
           "cluster": "in.9999",
           "destination_ip_list": [
            "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
+          "destination_ip_list": [
+           "10.2.0.0/32"
           ]
          }
         ]

--- a/test/mock/service.go
+++ b/test/mock/service.go
@@ -89,6 +89,10 @@ func MakeService(hostname, address string) *model.Service {
 				Name:     "custom",
 				Port:     90, // target port 1090
 				Protocol: model.ProtocolTCP,
+			}, {
+				Name:     "mongo",
+				Port:     100, // target port 1100
+				Protocol: model.ProtocolMONGO,
 			}},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Recognizes ports named mongo and enables Envoy's mongoDB filter accordingly.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #1127 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support for mongodb metrics through Envoy
```
