### PR TITLE
in make setup: do not create platform/kube/config if it already exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 SHELL := /bin/bash
 
 .PHONY: setup
-setup: kubeconfig
+setup: platform/kube/config
 	@bin/install-prereqs.sh
 	@bin/init.sh
 
@@ -51,6 +51,6 @@ gazelle:
 racetest:
 	@bazel test --features=race //...
 
-kubeconfig:
+platform/kube/config:
 	@ln -s ~/.kube/config platform/kube/
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Today, running `make setup` twice fails due to an attempt to create platform/kube/config (soft link), while it already exists. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```