### PR TITLE
Rename gobuild script to gocompile to avoid bazelify horror

### DIFF
--- a/bin/gocompile-and-push-images
+++ b/bin/gocompile-and-push-images
@@ -17,7 +17,7 @@
 ################################################################################
 #
 # This script creates a base image for the init image that includes iptables.
-#
+# Prior to running this script, make sure to run 'dep ensure' to pull vendor dependencies
 
 set -ex
 set -o errexit
@@ -39,10 +39,11 @@ done
 export GOOS=linux
 export GOARCH=amd64
 
-echo "Make sure to run 'dep ensure' to pull vendor dependencies."
+echo "Prior to running this script, make sure to run 'dep ensure' to pull vendor dependencies."
 
 go build ./cmd/pilot-agent
 go build ./cmd/pilot-discovery
+go build ./cmd/sidecar-initializer
 go build ./test/server
 go build ./test/client
 
@@ -51,6 +52,7 @@ cp -f  client docker/client
 cp -f  server docker/server
 cp -f  pilot-agent docker/pilot-agent
 cp -f  pilot-discovery docker/pilot-discovery
+cp -f  sidecar-initializer docker/sidecar-initializer
 
 # Build and push images
 if [[ "$hub" =~ ^gcr\.io ]]; then
@@ -58,7 +60,7 @@ if [[ "$hub" =~ ^gcr\.io ]]; then
 fi
 
 pushd docker
-  for image in app proxy proxy_init proxy_debug pilot; do
+  for image in app proxy proxy_init proxy_debug pilot sidecar_initializer; do
     docker build -f "Dockerfile.${image}" -t "$hub/$image:$tag" .
     docker push "$hub/$image:$tag"
   done


### PR DESCRIPTION
Bazelify wrongly belived a file called gobuild is a bazel build file.