### PR TITLE
Bazel 0.5.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,16 @@ ifeq ($(detected_OS),Darwin)  # Mac OS X
     BUILD_FLAGS = --cpu=k8
 endif
 
+hub = ""
+tag = ""
+ifneq ("x${HUB}", "x")
+	hub = -hub ${HUB}
+endif
+
+ifneq ("x${TAG}", "x")
+	tag = -tag ${TAG}
+endif
+
 .PHONY: setup
 setup: platform/kube/config
 	@bin/install-prereqs.sh
@@ -32,6 +42,10 @@ fmt:
 .PHONY: build
 build:	
 	@bazel build ${BUILD_FLAGS} //...
+
+.PHONY: docker
+docker:
+	@bin/push-docker ${hub} ${tag}
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@
 
 SHELL := /bin/bash
 
+detected_OS := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+BUILD_FLAGS = ""
+ifeq ($(detected_OS),Darwin)  # Mac OS X
+    BUILD_FLAGS = --cpu=k8
+endif
+
 .PHONY: setup
 setup: platform/kube/config
 	@bin/install-prereqs.sh
@@ -25,7 +31,7 @@ fmt:
 
 .PHONY: build
 build:	
-	@bazel build //...
+	@bazel build ${BUILD_FLAGS} //...
 
 .PHONY: clean
 clean:
@@ -33,7 +39,7 @@ clean:
 
 .PHONY: test
 test: build
-	@bazel test //...
+	@bazel test ${BUILD_FLAGS} //...
 
 .PHONY: coverage
 coverage:
@@ -49,7 +55,7 @@ gazelle:
 
 .PHONY: racetest
 racetest:
-	@bazel test --features=race //...
+	@bazel test ${BUILD_FLAGS} --features=race //...
 
 platform/kube/config:
 	@ln -s ~/.kube/config platform/kube/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "com_github_istio_pilot")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "eba68677493422112dd25f6a0b4bbdb02387e5a4",  # Aug 1, 2017
+    commit = "44231d643dfaf0c40bcad7eb4b8b2c3e7a08a63f",  # Sep 5, 2017
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -8,8 +8,16 @@ if [ $PDIR != "$GOPATH/src/istio.io/pilot" ]; then
        exit 1
 fi
 
+detected_OS=`uname -s 2>/dev/null || echo not`
+BUILD_FLAGS="--output_groups=static"
+SUFFIX=".static"
+if [ "${detected_OS}" == "Darwin" ]; then # Mac OS X
+    BUILD_FLAGS="--cpu=k8"
+    SUFFIX=""
+fi
+
 # Building and testing with Bazel
-bazel build //...
+bazel build ${BUILD_FLAGS} //...
 
 # Clean up vendor dir
 rm -rf $(pwd)/vendor

--- a/bin/push-docker
+++ b/bin/push-docker
@@ -24,6 +24,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+detected_OS=`uname -s 2>/dev/null || echo not`
+BUILD_FLAGS="--output_groups=static"
+SUFFIX=".static"
+if [ "${detected_OS}" == "Darwin" ]; then # Mac OS X
+    BUILD_FLAGS="--cpu=k8"
+    SUFFIX=""
+fi
 
 function docker_push() {
   im="${1}"
@@ -49,12 +56,12 @@ done
 
 # Collect artifacts for pushing
 bin=$(bazel info bazel-bin)
-bazel build --output_groups=static //cmd/... //test/...
-\cp -f  "${bin}/test/client/client.static" docker/client
-\cp -f  "${bin}/test/server/server.static" docker/server
-\cp -f  "${bin}/cmd/pilot-agent/pilot-agent.static" docker/pilot-agent
-\cp -f  "${bin}/cmd/pilot-discovery/pilot-discovery.static" docker/pilot-discovery
-\cp -f  "${bin}/cmd/sidecar-initializer/sidecar-initializer.static" docker/sidecar-initializer
+bazel build ${BUILD_FLAGS} //cmd/... //test/...
+\cp -f  "${bin}/test/client/client${SUFFIX}" docker/client
+\cp -f  "${bin}/test/server/server${SUFFIX}" docker/server
+\cp -f  "${bin}/cmd/pilot-agent/pilot-agent${SUFFIX}" docker/pilot-agent
+\cp -f  "${bin}/cmd/pilot-discovery/pilot-discovery${SUFFIX}" docker/pilot-discovery
+\cp -f  "${bin}/cmd/sidecar-initializer/sidecar-initializer${SUFFIX}" docker/sidecar-initializer
 
 # Build and push images
 
@@ -69,7 +76,7 @@ pushd docker
       for hub in ${hubs[@]}; do
         tagged_image="${hub}/${image}:${tag}"
         docker tag "${local_image}" "${tagged_image}"
-        docker_push "${tagged_image}"
+        #docker_push "${tagged_image}"
       done
     done
   done

--- a/bin/push-docker
+++ b/bin/push-docker
@@ -76,7 +76,7 @@ pushd docker
       for hub in ${hubs[@]}; do
         tagged_image="${hub}/${image}:${tag}"
         docker tag "${local_image}" "${tagged_image}"
-        #docker_push "${tagged_image}"
+        docker_push "${tagged_image}"
       done
     done
   done


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade rules_go and move to bazel 0.5.4. Supports native mac build with cross compilation.
Fixes to Makefiles to autodetect the platform and trigger bazel cross compilation.
Works cleanly with minikube.

```bash
make build
make docker HUB=docker.io/foo
```

Unfortunately, upgrading rules_go upgrades to go 1.9. 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```

@kyessenov is going to hate me for this makefile madness but it beats the non determinism we have today in test infra.