### PR TITLE
implementation of egress rules with one domain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -478,7 +478,7 @@ go_proto_library(
     ],
 )
     """,
-    commit = "311e590ce33153e953200c8573028ec37f32ddfd",  # Aug 29, 2017
+    commit = "88dd261709ccd8fa8a43bec5e3c15071d39bfc7c",  # Sep 07, 2017
     remote = "https://github.com/istio/api.git",
 )
 

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -485,14 +485,19 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 	}{
 		{name: "no conflicts",
 			in: map[string]*proxyconfig.EgressRule{"cnn": {
-				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Destination: &proxyconfig.IstioService{
+					Service: "*cnn.com",
+				},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
 				},
 			},
 				"bbc": {
-					Domains: []string{"*bbc.com", "*.bbc.com"},
+					Destination: &proxyconfig.IstioService{
+						Service: "*bbc.com",
+					},
+
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
 						{Port: 443, Protocol: "https"},
@@ -500,14 +505,18 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 				},
 			},
 			out: map[string]*proxyconfig.EgressRule{"cnn": {
-				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Destination: &proxyconfig.IstioService{
+					Service: "*cnn.com",
+				},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
 				},
 			},
 				"bbc": {
-					Domains: []string{"*bbc.com", "*.bbc.com"},
+					Destination: &proxyconfig.IstioService{
+						Service: "*bbc.com",
+					},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
 						{Port: 443, Protocol: "https"},
@@ -517,14 +526,18 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 			valid: true},
 		{name: "a conflict in a domain",
 			in: map[string]*proxyconfig.EgressRule{"cnn2": {
-				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Destination: &proxyconfig.IstioService{
+					Service: "*cnn.com",
+				},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
 				},
 			},
 				"cnn1": {
-					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Destination: &proxyconfig.IstioService{
+						Service: "*cnn.com",
+					},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
 						{Port: 443, Protocol: "https"},
@@ -533,7 +546,9 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 			},
 			out: map[string]*proxyconfig.EgressRule{
 				"cnn1": {
-					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Destination: &proxyconfig.IstioService{
+						Service: "*cnn.com",
+					},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
 						{Port: 443, Protocol: "https"},
@@ -543,93 +558,59 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 			valid: false},
 		{name: "a conflict in a domain, different ports",
 			in: map[string]*proxyconfig.EgressRule{"cnn2": {
-				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Destination: &proxyconfig.IstioService{
+					Service: "*cnn.com",
+				},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
 				},
 			},
 				"cnn1": {
-					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Destination: &proxyconfig.IstioService{
+						Service: "*cnn.com",
+					},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 8080, Protocol: "http"},
 						{Port: 8081, Protocol: "https"},
-					},
-				},
-			},
-			out: map[string]*proxyconfig.EgressRule{"cnn2": {
-				Domains: []string{"*cnn.com", "*.cnn.com"},
-				Ports: []*proxyconfig.EgressRule_Port{
-					{Port: 80, Protocol: "http"},
-					{Port: 443, Protocol: "https"},
-				},
-			},
-				"cnn1": {
-					Domains: []string{"*cnn.com", "*.cnn.de"},
-					Ports: []*proxyconfig.EgressRule_Port{
-						{Port: 8080, Protocol: "http"},
-						{Port: 8081, Protocol: "https"},
-					},
-				},
-			},
-			valid: true},
-		{name: "two conflicts, one rule rejected",
-			in: map[string]*proxyconfig.EgressRule{"cnn2": {
-				Domains: []string{"*cnn.com", "*.cnn.com"},
-				Ports: []*proxyconfig.EgressRule_Port{
-					{Port: 80, Protocol: "http"},
-					{Port: 443, Protocol: "https"},
-				},
-			},
-				"cnn1": {
-					Domains: []string{"*cnn.com", "*.cnn.de"},
-					Ports: []*proxyconfig.EgressRule_Port{
-						{Port: 80, Protocol: "http"},
-						{Port: 443, Protocol: "https"},
-					},
-				},
-				"cnn3": {
-					Domains: []string{"*.cnn.com", "edition.cnn.com"},
-					Ports: []*proxyconfig.EgressRule_Port{
-						{Port: 80, Protocol: "http"},
-						{Port: 443, Protocol: "https"},
 					},
 				},
 			},
 			out: map[string]*proxyconfig.EgressRule{
 				"cnn1": {
-					Domains: []string{"*cnn.com", "*.cnn.de"},
-					Ports: []*proxyconfig.EgressRule_Port{
-						{Port: 80, Protocol: "http"},
-						{Port: 443, Protocol: "https"},
+					Destination: &proxyconfig.IstioService{
+						Service: "*cnn.com",
 					},
-				},
-				"cnn3": {
-					Domains: []string{"*.cnn.com", "edition.cnn.com"},
 					Ports: []*proxyconfig.EgressRule_Port{
-						{Port: 80, Protocol: "http"},
-						{Port: 443, Protocol: "https"},
+						{Port: 8080, Protocol: "http"},
+						{Port: 8081, Protocol: "https"},
 					},
 				},
 			},
 			valid: false},
 		{name: "two conflicts, two rules rejected",
 			in: map[string]*proxyconfig.EgressRule{"cnn2": {
-				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Destination: &proxyconfig.IstioService{
+					Service: "*cnn.com",
+				},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
 				},
 			},
 				"cnn1": {
-					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Destination: &proxyconfig.IstioService{
+						Service: "*cnn.com",
+					},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
 						{Port: 443, Protocol: "https"},
 					},
 				},
 				"cnn3": {
-					Domains: []string{"*.cnn.de", "edition.cnn.com"},
+					Destination: &proxyconfig.IstioService{
+						Service: "*cnn.com",
+					},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
 						{Port: 443, Protocol: "https"},
@@ -638,7 +619,9 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 			},
 			out: map[string]*proxyconfig.EgressRule{
 				"cnn1": {
-					Domains: []string{"*cnn.com", "*.cnn.de"},
+					Destination: &proxyconfig.IstioService{
+						Service: "*cnn.com",
+					},
 					Ports: []*proxyconfig.EgressRule_Port{
 						{Port: 80, Protocol: "http"},
 						{Port: 443, Protocol: "https"},

--- a/model/validation_test.go
+++ b/model/validation_test.go
@@ -206,6 +206,7 @@ func TestServiceInstanceValidate(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
+		t.Log("running case " + c.name)
 		if got := c.instance.Validate(); (got == nil) != c.valid {
 			t.Errorf("%s failed: got valid=%v but wanted valid=%v: %v", c.name, got == nil, c.valid, got)
 		}
@@ -847,7 +848,9 @@ func TestValidateEgressRule(t *testing.T) {
 		{name: "empty egress rule", in: &proxyconfig.EgressRule{}, valid: false},
 		{name: "valid egress rule",
 			in: &proxyconfig.EgressRule{
-				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Destination: &proxyconfig.IstioService{
+					Service: "*cnn.com",
+				},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
@@ -856,16 +859,18 @@ func TestValidateEgressRule(t *testing.T) {
 			valid: true},
 		{name: "egress rule with use_egress_proxy = true, not yet implemented",
 			in: &proxyconfig.EgressRule{
-				Domains: []string{"*cnn.com"},
+				Destination: &proxyconfig.IstioService{
+					Service: "*cnn.com",
+				},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 8080, Protocol: "http"},
 				},
 				UseEgressProxy: true},
 			valid: false},
-		{name: "empty domains",
+		{name: "empty destination",
 			in: &proxyconfig.EgressRule{
-				Domains: []string{},
+				Destination: &proxyconfig.IstioService{},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},
@@ -874,22 +879,17 @@ func TestValidateEgressRule(t *testing.T) {
 			valid: false},
 		{name: "empty ports",
 			in: &proxyconfig.EgressRule{
-				Domains:        []string{"*cnn.com", "*.cnn.com"},
-				Ports:          []*proxyconfig.EgressRule_Port{},
-				UseEgressProxy: false},
-			valid: false},
-		{name: "duplicate domain",
-			in: &proxyconfig.EgressRule{
-				Domains: []string{"*cnn.com", "*.cnn.com", "*cnn.com"},
-				Ports: []*proxyconfig.EgressRule_Port{
-					{Port: 80, Protocol: "http"},
-					{Port: 443, Protocol: "https"},
+				Destination: &proxyconfig.IstioService{
+					Service: "*cnn.com",
 				},
+				Ports:          []*proxyconfig.EgressRule_Port{},
 				UseEgressProxy: false},
 			valid: false},
 		{name: "duplicate port",
 			in: &proxyconfig.EgressRule{
-				Domains: []string{"*cnn.com", "*.cnn.com"},
+				Destination: &proxyconfig.IstioService{
+					Service: "*cnn.com",
+				},
 				Ports: []*proxyconfig.EgressRule_Port{
 					{Port: 80, Protocol: "http"},
 					{Port: 443, Protocol: "https"},

--- a/test/mock/config.go
+++ b/test/mock/config.go
@@ -55,7 +55,9 @@ var (
 
 	// ExampleEgressRule is an example egress rule
 	ExampleEgressRule = &proxyconfig.EgressRule{
-		Domains:        []string{"*.cnn.com", "*.cnn.de"},
+		Destination: &proxyconfig.IstioService{
+			Service: "*cnn.com",
+		},
 		Ports:          []*proxyconfig.EgressRule_Port{{Port: 80, Protocol: "http"}},
 		UseEgressProxy: false,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements handling egress rules according to the new format - one domain, using IstioService for destination

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1180

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
```