### PR TITLE
Increase default ResyncPeriod from 1 to 60 seconds

### DIFF
--- a/cmd/pilot-discovery/main.go
+++ b/cmd/pilot-discovery/main.go
@@ -184,7 +184,7 @@ func init() {
 	discoveryCmd.PersistentFlags().StringVarP(&flags.controllerOptions.WatchedNamespace, "app namespace",
 		"a", metav1.NamespaceAll,
 		"Restrict the applications namespace the controller manages; if not set, controller watches all namespaces")
-	discoveryCmd.PersistentFlags().DurationVar(&flags.controllerOptions.ResyncPeriod, "resync", time.Second,
+	discoveryCmd.PersistentFlags().DurationVar(&flags.controllerOptions.ResyncPeriod, "resync", 60*time.Second,
 		"Controller resync interval")
 	discoveryCmd.PersistentFlags().StringVar(&flags.controllerOptions.DomainSuffix, "domain", "cluster.local",
 		"DNS domain suffix")


### PR DESCRIPTION
Pilot currently uses 1 second resync period which puts additional load
on apiserver. This is not necessary and doesn't scale well in shared
test clusters. Increase to 60 seconds for now with the possibility of
further increases if this doesn't cause test instability.

See
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/kubernetes-sig-api-machinery/PbSCXdLDno0/v9gH3HXVDAAJ
for recommendations on setting resync period.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
