### PR TITLE
Change the default version used by kube-inject to be the full SHA

### DIFF
--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -30,7 +30,7 @@ function get_branch() {
     fi
 }
 
-BUILD_GIT_REVISION=$(git rev-parse --short HEAD 2> /dev/null)
+BUILD_GIT_REVISION=$(git rev-parse HEAD 2> /dev/null)
 if [[  $? == 0 ]]; then
     BRANCH="$(get_branch)"
     git diff-index --quiet HEAD


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
