### PR TITLE
Use pilot master instead of stable

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -3,21 +3,21 @@
 		"_comment": "The script to update dependency is at https://github.com/istio/test-infra/blob/master/toolbox/deps_update/main.go",
 		"name": "ISTIO_PROXY_BUCKET",
 		"repoName": "proxy",
-		"prodBranch": "stable",
+		"prodBranch": "master",
 		"file": "WORKSPACE",
 		"lastStableSHA": "62755c63d9c80c043ece26504c4288845a929cc4"
 	},
 	{
 		"name": "/envoy",
 		"repoName": "proxy",
-		"prodBranch": "stable",
+		"prodBranch": "master",
 		"file": "docker/Dockerfile.proxy",
 		"lastStableSHA": "62755c63d9c80c043ece26504c4288845a929cc4"
 	},
 	{
 		"name": "/envoy-debug",
 		"repoName": "proxy",
-		"prodBranch": "stable",
+		"prodBranch": "master",
 		"file": "docker/Dockerfile.proxy_debug",
 		"lastStableSHA": "62755c63d9c80c043ece26504c4288845a929cc4"
 	}


### PR DESCRIPTION
Postsubmit jobs of Proxy are still on Jenkins and fast forwarding stable branch was suspended. Use Proxy master branch to update pilot instead.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
