### PR TITLE
Use rbac+auth e2e

### DIFF
--- a/prow/pilot-e2e-smoketest.sh
+++ b/prow/pilot-e2e-smoketest.sh
@@ -54,7 +54,7 @@ echo "=== Smoke Test ==="
 #
 # In the future, this should be parameterized similarly to the integration tests, with the kubeconfig
 # location specified explicitly.
-./prow/e2e-suite-rbac-no_auth.sh \
+./prow/e2e-suite-rbac-auth.sh \
     --pilot_hub="${HUB}" \
     --pilot_tag="${GIT_SHA}" \
     --istioctl_url="${ISTIOCTL_URL}"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

As decided, we are switching to use rbac-auth as e2e-gate
