### PR TITLE
adding --service-zone flag to Envoy

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -478,7 +478,7 @@ go_proto_library(
     ],
 )
     """,
-    commit = "0ab63a64b7ce7900de2a95160c13dcf781d04d07",  # Sep 08, 2017
+    commit = "6838a2bfc42260cf0513552a64a457f1cf39041c",  # Sep 10, 2017
     remote = "https://github.com/istio/api.git",
 )
 

--- a/cmd/pilot-agent/main.go
+++ b/cmd/pilot-agent/main.go
@@ -42,7 +42,7 @@ var (
 	configPath             string
 	binaryPath             string
 	serviceCluster         string
-	serviceZone            string
+	availabilityZone       string
 	drainDuration          time.Duration
 	parentShutdownDuration time.Duration
 	discoveryAddress       string
@@ -105,7 +105,7 @@ var (
 			proxyConfig.ConfigPath = configPath
 			proxyConfig.BinaryPath = binaryPath
 			proxyConfig.ServiceCluster = serviceCluster
-			proxyConfig.ServiceZone = serviceZone
+			proxyConfig.AvailabilityZone = availabilityZone
 			proxyConfig.DrainDuration = ptypes.DurationProto(drainDuration)
 			proxyConfig.ParentShutdownDuration = ptypes.DurationProto(parentShutdownDuration)
 			proxyConfig.DiscoveryAddress = discoveryAddress
@@ -193,8 +193,8 @@ func init() {
 		"Path to the proxy binary")
 	proxyCmd.PersistentFlags().StringVar(&serviceCluster, "serviceCluster", values.ServiceCluster,
 		"Service cluster")
-	proxyCmd.PersistentFlags().StringVar(&serviceZone, "serviceZone", values.ServiceZone,
-		"Service zone")
+	proxyCmd.PersistentFlags().StringVar(&availabilityZone, "availabilityZone", values.AvailabilityZone,
+		"Availability zone")
 	proxyCmd.PersistentFlags().DurationVar(&drainDuration, "drainDuration",
 		timeDuration(values.DrainDuration),
 		"The time in seconds that Envoy will drain connections during a hot restart")

--- a/cmd/pilot-agent/main.go
+++ b/cmd/pilot-agent/main.go
@@ -42,6 +42,7 @@ var (
 	configPath             string
 	binaryPath             string
 	serviceCluster         string
+	serviceZone            string
 	drainDuration          time.Duration
 	parentShutdownDuration time.Duration
 	discoveryAddress       string
@@ -104,6 +105,7 @@ var (
 			proxyConfig.ConfigPath = configPath
 			proxyConfig.BinaryPath = binaryPath
 			proxyConfig.ServiceCluster = serviceCluster
+			proxyConfig.ServiceZone = serviceZone
 			proxyConfig.DrainDuration = ptypes.DurationProto(drainDuration)
 			proxyConfig.ParentShutdownDuration = ptypes.DurationProto(parentShutdownDuration)
 			proxyConfig.DiscoveryAddress = discoveryAddress
@@ -191,6 +193,8 @@ func init() {
 		"Path to the proxy binary")
 	proxyCmd.PersistentFlags().StringVar(&serviceCluster, "serviceCluster", values.ServiceCluster,
 		"Service cluster")
+	proxyCmd.PersistentFlags().StringVar(&serviceZone, "serviceZone", values.ServiceZone,
+		"Service zone")
 	proxyCmd.PersistentFlags().DurationVar(&drainDuration, "drainDuration",
 		timeDuration(values.DrainDuration),
 		"The time in seconds that Envoy will drain connections during a hot restart")

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -128,7 +128,7 @@ func DefaultProxyConfig() proxyconfig.ProxyConfig {
 		ConfigPath:             "/etc/istio/proxy",
 		BinaryPath:             "/usr/local/bin/envoy",
 		ServiceCluster:         "istio-proxy",
-		ServiceZone:            "", //no service zone by default, i.e. AZ-aware routing is disabled
+		AvailabilityZone:       "", //no service zone by default, i.e. AZ-aware routing is disabled
 		DrainDuration:          ptypes.DurationProto(2 * time.Second),
 		ParentShutdownDuration: ptypes.DurationProto(3 * time.Second),
 		DiscoveryAddress:       "istio-pilot:8080",

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -128,6 +128,7 @@ func DefaultProxyConfig() proxyconfig.ProxyConfig {
 		ConfigPath:             "/etc/istio/proxy",
 		BinaryPath:             "/usr/local/bin/envoy",
 		ServiceCluster:         "istio-proxy",
+		ServiceZone:            "", //no service zone by default, i.e. AZ-aware routing is disabled
 		DrainDuration:          ptypes.DurationProto(2 * time.Second),
 		ParentShutdownDuration: ptypes.DurationProto(3 * time.Second),
 		DiscoveryAddress:       "istio-pilot:8080",

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -126,8 +126,8 @@ func (proxy envoy) args(fname string, epoch int) []string {
 		"--service-node", proxy.node,
 	}...)
 
-	if len(proxy.config.ServiceZone) > 0 {
-		startupArgs = append(startupArgs, []string {"--service-zone", proxy.config.ServiceZone}...)
+	if len(proxy.config.AvailabilityZone) > 0 {
+		startupArgs = append(startupArgs, []string{"--service-zone", proxy.config.AvailabilityZone}...)
 	}
 
 	return startupArgs

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -117,13 +117,20 @@ func NewProxy(config proxyconfig.ProxyConfig, node string) proxy.Proxy {
 }
 
 func (proxy envoy) args(fname string, epoch int) []string {
-	return []string{"-c", fname,
+	startupArgs := make([]string, 0)
+	startupArgs = append(startupArgs, []string{"-c", fname,
 		"--restart-epoch", fmt.Sprint(epoch),
 		"--drain-time-s", fmt.Sprint(int(convertDuration(proxy.config.DrainDuration) / time.Second)),
 		"--parent-shutdown-time-s", fmt.Sprint(int(convertDuration(proxy.config.ParentShutdownDuration) / time.Second)),
 		"--service-cluster", proxy.config.ServiceCluster,
 		"--service-node", proxy.node,
+	}...)
+
+	if len(proxy.config.ServiceZone) > 0 {
+		startupArgs = append(startupArgs, []string {"--service-zone", proxy.config.ServiceZone}...)
 	}
+
+	return startupArgs
 }
 
 func (proxy envoy) Run(config interface{}, epoch int, abort <-chan error) error {

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -117,14 +117,13 @@ func NewProxy(config proxyconfig.ProxyConfig, node string) proxy.Proxy {
 }
 
 func (proxy envoy) args(fname string, epoch int) []string {
-	startupArgs := make([]string, 0)
-	startupArgs = append(startupArgs, []string{"-c", fname,
+	startupArgs := []string{"-c", fname,
 		"--restart-epoch", fmt.Sprint(epoch),
 		"--drain-time-s", fmt.Sprint(int(convertDuration(proxy.config.DrainDuration) / time.Second)),
 		"--parent-shutdown-time-s", fmt.Sprint(int(convertDuration(proxy.config.ParentShutdownDuration) / time.Second)),
 		"--service-cluster", proxy.config.ServiceCluster,
 		"--service-node", proxy.node,
-	}...)
+	}
 
 	if len(proxy.config.AvailabilityZone) > 0 {
 		startupArgs = append(startupArgs, []string{"--service-zone", proxy.config.AvailabilityZone}...)

--- a/proxy/envoy/watcher_test.go
+++ b/proxy/envoy/watcher_test.go
@@ -24,7 +24,7 @@ import (
 func TestEnvoyArgs(t *testing.T) {
 	config := proxy.DefaultProxyConfig()
 	config.ServiceCluster = "my-cluster"
-	config.ServiceZone = "my-zone"
+	config.AvailabilityZone = "my-zone"
 
 	test := envoy{config: config, node: "my-node"}
 	got := test.args("test.json", 5)

--- a/proxy/envoy/watcher_test.go
+++ b/proxy/envoy/watcher_test.go
@@ -24,6 +24,7 @@ import (
 func TestEnvoyArgs(t *testing.T) {
 	config := proxy.DefaultProxyConfig()
 	config.ServiceCluster = "my-cluster"
+	config.ServiceZone = "my-zone"
 
 	test := envoy{config: config, node: "my-node"}
 	got := test.args("test.json", 5)
@@ -34,6 +35,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--parent-shutdown-time-s", "3",
 		"--service-cluster", "my-cluster",
 		"--service-node", "my-node",
+		"--service-zone", "my-zone",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("envoyArgs() => got %v, want %v", got, want)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an optional --availabilityZone flag to pilot-agent (which gets translated into --service-zone flag for Envoy). This lets the end user specify the availability zone associated with an envoy instance during startup time. It is possible to dynamically infer this from kubernetes, but it will bloat the pilot agent binary (40Mb+). If the flag is not specified, the service-zone flag will not be passed (this is the default for backward compatibility).

When injecting the pod from initializer or kube-inject, this flag will not be specified (and az aware routing will thus remain disabled). However, users wishing to manually inject the sidecar can specify the flag to take advantage of Envoy's az-aware routing.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1212 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ability to explicitly specify the availability zone associated with an Envoy sidecar in a pod
```
