### PR TITLE
Mixer filter: rename target->destination, and use mixer_check, mixer_report options

### DIFF
--- a/platform/kube/inject/inject.go
+++ b/platform/kube/inject/inject.go
@@ -264,7 +264,7 @@ func injectRequired(namespacePolicy InjectionPolicy, obj metav1.Object) bool {
 
 	status, ok := annotations[istioSidecarAnnotationStatusKey]
 
-	glog.V(2).Infof("Sidecar injection policy for %v/%v: namespace:%v useDefault:%v inject:%v status:%q required:%v",
+	glog.V(2).Infof("Sidecar injection policy for %v/%v: namespacePolicy:%v useDefault:%v inject:%v status:%q required:%v",
 		obj.GetNamespace(), obj.GetName(), namespacePolicy, useDefault, inject, status, required)
 
 	if !required {

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -617,7 +617,7 @@ func buildInboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node,
 
 			// set server-side mixer filter config for inbound HTTP routes
 			if mesh.MixerAddress != "" {
-				defaultRoute.OpaqueConfig = buildMixerOpaqueConfig(true, false)
+				defaultRoute.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, false)
 			}
 
 			host := &VirtualHost{
@@ -642,7 +642,7 @@ func buildInboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node,
 						// Note: websocket routes do not call the filter chain. Will be
 						// resolved in future.
 						if mesh.MixerAddress != "" {
-							websocketRoute.OpaqueConfig = buildMixerOpaqueConfig(true, false)
+							websocketRoute.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, false)
 						}
 
 						host.Routes = append(host.Routes, websocketRoute)
@@ -666,7 +666,7 @@ func buildInboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node,
 				filter := &NetworkFilter{
 					Type:   both,
 					Name:   MixerFilter,
-					Config: mixerTCPConfig(sidecar),
+					Config: mixerTCPConfig(sidecar, mesh.DisablePolicyChecks),
 				}
 				listener.Filters = append([]*NetworkFilter{filter}, listener.Filters...)
 			}

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -666,7 +666,7 @@ func buildInboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node,
 				filter := &NetworkFilter{
 					Type:   both,
 					Name:   MixerFilter,
-					Config: mixerTCPConfig(sidecar, mesh.DisablePolicyChecks),
+					Config: mixerTCPConfig(sidecar, !mesh.DisablePolicyChecks),
 				}
 				listener.Filters = append([]*NetworkFilter{filter}, listener.Filters...)
 			}

--- a/proxy/envoy/egress.go
+++ b/proxy/envoy/egress.go
@@ -84,7 +84,7 @@ func buildEgressHTTPRoute(mesh *proxyconfig.MeshConfig, svc *model.Service) *Vir
 
 			// enable mixer check on the route
 			if mesh.MixerAddress != "" {
-				route.OpaqueConfig = buildMixerOpaqueConfig(true, false)
+				route.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, false)
 			}
 
 			host = &VirtualHost{

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -156,7 +156,7 @@ func buildIngressRoute(mesh *proxyconfig.MeshConfig,
 	for _, route := range routes {
 		// enable mixer check on the route
 		if mesh.MixerAddress != "" {
-			route.OpaqueConfig = buildMixerOpaqueConfig(true, true)
+			route.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, true)
 		}
 
 		if applied := route.CombinePathPrefix(ingressRoute.Path, ingressRoute.Prefix); applied != nil {

--- a/proxy/envoy/mixer.go
+++ b/proxy/envoy/mixer.go
@@ -122,12 +122,12 @@ func mixerHTTPRouteConfig(role proxy.Node, service string) *FilterMixerConfig {
 }
 
 // Mixer TCP filter config for inbound requests
-func mixerTCPConfig(role proxy.Node, disableChecks bool) *FilterMixerConfig {
+func mixerTCPConfig(role proxy.Node, check bool) *FilterMixerConfig {
 	return &FilterMixerConfig{
 		MixerAttributes: map[string]string{
 			AttrDestinationIP:  role.IPAddress,
 			AttrDestinationUID: "kubernetes://" + role.ID,
 		},
-		DisableTCPCheckCalls: disableChecks,
+		DisableTCPCheckCalls: !check,
 	}
 }

--- a/proxy/envoy/mixer.go
+++ b/proxy/envoy/mixer.go
@@ -34,20 +34,26 @@ const (
 	// AttrSourceUID is platform-specific unique identifier for the client instance of the source service
 	AttrSourceUID = "source.uid"
 
-	// AttrTargetIP is the server source IP
-	AttrTargetIP = "target.ip"
+	// AttrDestinationIP is the server source IP
+	AttrDestinationIP = "destination.ip"
 
-	// AttrTargetUID is platform-specific unique identifier for the server instance of the target service
-	AttrTargetUID = "target.uid"
+	// AttrDestinationUID is platform-specific unique identifier for the server instance of the target service
+	AttrDestinationUID = "destination.uid"
 
-	// AttrTargetService is name of the target service
-	AttrTargetService = "target.service"
+	// AttrDestinationService is name of the target service
+	AttrDestinationService = "destination.service"
 
 	// MixerRequestCount is the quota bucket name
 	MixerRequestCount = "RequestCount"
 
-	// MixerControl switches Check call on and off
-	MixerControl = "mixer_control"
+	// MixerCheck switches Check call on and off
+	MixerCheck = "mixer_check"
+
+	// MixerReport switches Report call on and off
+	MixerReport = "mixer_report"
+
+	// DisableTCPCheckCalls switches Check call on and off for tcp listeners
+	DisableTCPCheckCalls = "disable_tcp_check_calls"
 
 	// MixerForward switches attribute forwarding on and off
 	MixerForward = "mixer_forward"
@@ -66,6 +72,9 @@ type FilterMixerConfig struct {
 	// QuotaName specifies the name of the quota bucket to withdraw tokens from;
 	// an empty name means no quota will be charged.
 	QuotaName string `json:"quota_name,omitempty"`
+
+	// If set to true, disables mixer check calls for TCP connections
+	DisableTCPCheckCalls bool `json:"disable_tcp_check_calls,omitempty"`
 }
 
 func (*FilterMixerConfig) isNetworkFilterConfig() {}
@@ -85,7 +94,8 @@ func buildMixerCluster(mesh *proxyconfig.MeshConfig) *Cluster {
 func buildMixerOpaqueConfig(check, forward bool) map[string]string {
 	keys := map[bool]string{true: "on", false: "off"}
 	return map[string]string{
-		MixerControl: keys[check],
+		MixerReport:  "on",
+		MixerCheck:   keys[check],
 		MixerForward: keys[forward],
 	}
 }
@@ -95,8 +105,8 @@ func buildMixerOpaqueConfig(check, forward bool) map[string]string {
 func mixerHTTPRouteConfig(role proxy.Node, service string) *FilterMixerConfig {
 	r := &FilterMixerConfig{
 		MixerAttributes: map[string]string{
-			AttrTargetIP:  role.IPAddress,
-			AttrTargetUID: "kubernetes://" + role.ID,
+			AttrDestinationIP:  role.IPAddress,
+			AttrDestinationUID: "kubernetes://" + role.ID,
 		},
 		ForwardAttributes: map[string]string{
 			AttrSourceIP:  role.IPAddress,
@@ -105,18 +115,19 @@ func mixerHTTPRouteConfig(role proxy.Node, service string) *FilterMixerConfig {
 		QuotaName: MixerRequestCount,
 	}
 	if len(service) > 0 {
-		r.MixerAttributes[AttrTargetService] = service
+		r.MixerAttributes[AttrDestinationService] = service
 	}
 
 	return r
 }
 
 // Mixer TCP filter config for inbound requests
-func mixerTCPConfig(role proxy.Node) *FilterMixerConfig {
+func mixerTCPConfig(role proxy.Node, disableChecks bool) *FilterMixerConfig {
 	return &FilterMixerConfig{
 		MixerAttributes: map[string]string{
-			AttrTargetIP:  role.IPAddress,
-			AttrTargetUID: "kubernetes://" + role.ID,
+			AttrDestinationIP:  role.IPAddress,
+			AttrDestinationUID: "kubernetes://" + role.ID,
 		},
+		DisableTCPCheckCalls: disableChecks,
 	}
 }

--- a/proxy/envoy/testdata/lds-egress-auth.json.golden
+++ b/proxy/envoy/testdata/lds-egress-auth.json.golden
@@ -25,8 +25,8 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.3.3.4",
-           "target.uid": "kubernetes://egress.default"
+           "destination.ip": "10.3.3.4",
+           "destination.uid": "kubernetes://egress.default"
           },
           "forward_attributes": {
            "source.ip": "10.3.3.4",

--- a/proxy/envoy/testdata/lds-egress.json.golden
+++ b/proxy/envoy/testdata/lds-egress.json.golden
@@ -25,8 +25,8 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.3.3.4",
-           "target.uid": "kubernetes://egress.default"
+           "destination.ip": "10.3.3.4",
+           "destination.uid": "kubernetes://egress.default"
           },
           "forward_attributes": {
            "source.ip": "10.3.3.4",

--- a/proxy/envoy/testdata/lds-httpproxy.json.golden
+++ b/proxy/envoy/testdata/lds-httpproxy.json.golden
@@ -25,9 +25,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",

--- a/proxy/envoy/testdata/lds-ingress.json.golden
+++ b/proxy/envoy/testdata/lds-ingress.json.golden
@@ -26,8 +26,8 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.3.3.3",
-           "target.uid": "kubernetes://ingress.default"
+           "destination.ip": "10.3.3.3",
+           "destination.uid": "kubernetes://ingress.default"
           },
           "forward_attributes": {
            "source.ip": "10.3.3.3",
@@ -78,8 +78,8 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.3.3.3",
-           "target.uid": "kubernetes://ingress.default"
+           "destination.ip": "10.3.3.3",
+           "destination.uid": "kubernetes://ingress.default"
           },
           "forward_attributes": {
            "source.ip": "10.3.3.3",

--- a/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -168,9 +168,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -308,8 +308,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -322,9 +323,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -364,8 +365,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -404,8 +405,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -492,8 +493,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -506,9 +508,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",

--- a/proxy/envoy/testdata/lds-v0-fault.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -168,9 +168,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -308,8 +308,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -322,9 +323,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -358,8 +359,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -392,8 +393,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -474,8 +475,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -488,9 +490,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",

--- a/proxy/envoy/testdata/lds-v0-none-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none-auth.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -244,8 +244,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -258,9 +259,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -300,8 +301,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -340,8 +341,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -428,8 +429,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -442,9 +444,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",

--- a/proxy/envoy/testdata/lds-v0-none.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -244,8 +244,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -258,9 +259,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -294,8 +295,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -328,8 +329,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -410,8 +411,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -424,9 +426,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",

--- a/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -244,8 +244,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -258,9 +259,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -300,8 +301,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -340,8 +341,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -428,8 +429,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -442,9 +444,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",

--- a/proxy/envoy/testdata/lds-v0-weighted.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -244,8 +244,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -258,9 +259,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -294,8 +295,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -328,8 +329,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -410,8 +411,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -424,9 +426,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",

--- a/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -244,8 +244,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -258,9 +259,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -300,8 +301,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -340,8 +341,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -428,8 +429,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -442,9 +444,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",

--- a/proxy/envoy/testdata/lds-v1-fault.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -244,8 +244,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -258,9 +259,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -294,8 +295,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -328,8 +329,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -410,8 +411,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -424,9 +426,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",

--- a/proxy/envoy/testdata/lds-v1-none-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none-auth.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -244,8 +244,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -258,9 +259,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -300,8 +301,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -340,8 +341,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -428,8 +429,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -442,9 +444,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",

--- a/proxy/envoy/testdata/lds-v1-none.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -244,8 +244,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -258,9 +259,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -294,8 +295,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -328,8 +329,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -410,8 +411,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -424,9 +426,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",

--- a/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -244,8 +244,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -258,9 +259,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -300,8 +301,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -340,8 +341,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -428,8 +429,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -442,9 +444,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",

--- a/proxy/envoy/testdata/lds-v1-weighted.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -244,8 +244,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -258,9 +259,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",
@@ -294,8 +295,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -328,8 +329,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.1",
-        "target.uid": "kubernetes://v1.default"
+        "destination.ip": "10.1.1.1",
+        "destination.uid": "kubernetes://v1.default"
        }
       }
      },
@@ -410,8 +411,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -424,9 +426,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.1",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v1.default"
+           "destination.ip": "10.1.1.1",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v1.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.1",

--- a/proxy/envoy/testdata/lds-websocket.json.golden
+++ b/proxy/envoy/testdata/lds-websocket.json.golden
@@ -32,9 +32,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -84,9 +84,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -136,9 +136,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -244,8 +244,9 @@
             "prefix": "/websocket",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             },
             "use_websocket": true
            },
@@ -253,8 +254,9 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -267,9 +269,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",
@@ -303,8 +305,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -337,8 +339,8 @@
       "name": "mixer",
       "config": {
        "mixer_attributes": {
-        "target.ip": "10.1.1.0",
-        "target.uid": "kubernetes://v0.default"
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
        }
       }
      },
@@ -419,8 +421,9 @@
             "prefix": "/websocket",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             },
             "use_websocket": true
            },
@@ -428,8 +431,9 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
-             "mixer_control": "on",
-             "mixer_forward": "off"
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
             }
            }
           ]
@@ -442,9 +446,9 @@
          "name": "mixer",
          "config": {
           "mixer_attributes": {
-           "target.ip": "10.1.1.0",
-           "target.service": "hello.default.svc.cluster.local",
-           "target.uid": "kubernetes://v0.default"
+           "destination.ip": "10.1.1.0",
+           "destination.service": "hello.default.svc.cluster.local",
+           "destination.uid": "kubernetes://v0.default"
           },
           "forward_attributes": {
            "source.ip": "10.1.1.0",

--- a/proxy/envoy/testdata/rds-egress.json.golden
+++ b/proxy/envoy/testdata/rds-egress.json.golden
@@ -10,8 +10,9 @@
       "prefix": "/",
       "cluster": "ae8d3361601f8293abe6ac5e4d807124612cf42e",
       "opaque_config": {
-       "mixer_control": "on",
-       "mixer_forward": "off"
+       "mixer_check": "on",
+       "mixer_forward": "off",
+       "mixer_report": "on"
       },
       "auto_host_rewrite": true
      }
@@ -27,8 +28,9 @@
       "prefix": "/",
       "cluster": "242bc3028e0f3fe0682e6d972e167ab415b2321d",
       "opaque_config": {
-       "mixer_control": "on",
-       "mixer_forward": "off"
+       "mixer_check": "on",
+       "mixer_forward": "off",
+       "mixer_report": "on"
       },
       "auto_host_rewrite": true
      }

--- a/proxy/envoy/testdata/rds-ingress-ssl.json.golden
+++ b/proxy/envoy/testdata/rds-ingress-ssl.json.golden
@@ -10,8 +10,9 @@
       "prefix": "/bar",
       "cluster": "out.81c187d71467b1608736c57bb0734f9ef9b68f7d",
       "opaque_config": {
-       "mixer_control": "on",
-       "mixer_forward": "on"
+       "mixer_check": "on",
+       "mixer_forward": "on",
+       "mixer_report": "on"
       }
      }
     ]

--- a/proxy/envoy/testdata/rds-ingress-weighted.json.golden
+++ b/proxy/envoy/testdata/rds-ingress-weighted.json.golden
@@ -21,8 +21,9 @@
        ]
       },
       "opaque_config": {
-       "mixer_control": "on",
-       "mixer_forward": "on"
+       "mixer_check": "on",
+       "mixer_forward": "on",
+       "mixer_report": "on"
       }
      }
     ]

--- a/proxy/envoy/testdata/rds-ingress.json.golden
+++ b/proxy/envoy/testdata/rds-ingress.json.golden
@@ -10,8 +10,9 @@
       "path": "/hello",
       "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74",
       "opaque_config": {
-       "mixer_control": "on",
-       "mixer_forward": "on"
+       "mixer_check": "on",
+       "mixer_forward": "on",
+       "mixer_report": "on"
       }
      }
     ]

--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -59,7 +59,7 @@ const (
 	caImage = "gcr.io/istio-testing/istio-ca:2baec6baacecbd516ea0880573b6fc3cd5736739"
 
 	// mixerImage specifies the default mixer docker image used for e2e testing *update manually*
-	mixerImage = "gcr.io/istio-testing/mixer:986c6e1eb9c7dcff42e3df5aefa9ce858ece885e"
+	mixerImage = "gcr.io/istio-testing/mixer:36994fb05d97abfa44761bafa5d1efec8d132b47"
 
 	// retry budget
 	budget = 90


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename the last vestiges of target.* attributes in Pilot, now that Mixer has support for destination.* attributes. Also, since proxy supports fine grained mixer_check/mixer_report attributes, enable those instead of coarse grained mixer_control flag. Mixer_check can be disabled globally by the user using DisablePolicyCheck flag.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1227 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ability to turn of mixer policy checks independent of mixer metrics reports.
```
