### PR TITLE
egress bug fix: do not enable LB and auth for egress rules, add egress rules for http_proxy

### DIFF
--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -222,6 +222,7 @@ func buildSidecarListenersClusters(
 	if mesh.ProxyHttpPort > 0 {
 		// only HTTP outbound clusters are needed
 		httpOutbound := buildOutboundHTTPRoutes(mesh, node, instances, services, config)
+		httpOutbound = buildEgressFromSidecarHTTPRoutes(mesh, config.EgressRules(), httpOutbound)
 		clusters = append(clusters,
 			httpOutbound.clusters()...)
 		listeners = append(listeners,


### PR DESCRIPTION
**What this PR does / why we need it**:
Load balancing and auth should be disabled for egress rules talking to external services. Routes for http proxy should include egress rules in addition to standard services in k8s.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
