### PR TITLE
Make sure ProxyConfig defaults are applied

### DIFF
--- a/cmd/BUILD
+++ b/cmd/BUILD
@@ -5,7 +5,6 @@ go_library(
     srcs = ["cmd.go"],
     visibility = ["//visibility:public"],
     deps = [
-        "//model:go_default_library",
         "//proxy:go_default_library",
         "//tools/version:go_default_library",
         "@com_github_golang_glog//:go_default_library",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 
 	proxyconfig "istio.io/api/proxy/v1/config"
-	"istio.io/pilot/model"
 	"istio.io/pilot/proxy"
 	"istio.io/pilot/tools/version"
 )
@@ -38,17 +37,7 @@ func ReadMeshConfig(filename string) (*proxyconfig.MeshConfig, error) {
 	if err != nil {
 		return nil, multierror.Prefix(err, "cannot read mesh config file")
 	}
-
-	mesh := proxy.DefaultMeshConfig()
-	if err = model.ApplyYAML(string(yaml), &mesh); err != nil {
-		return nil, multierror.Prefix(err, "failed to convert to proto.")
-	}
-
-	if err = model.ValidateMeshConfig(&mesh); err != nil {
-		return nil, err
-	}
-
-	return &mesh, nil
+	return proxy.ApplyMeshConfigDefaults(string(yaml))
 }
 
 // VersionCmd is a sub-command to print version information

--- a/platform/kube/inject/BUILD
+++ b/platform/kube/inject/BUILD
@@ -10,7 +10,6 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//model:go_default_library",
         "//proxy:go_default_library",
         "//tools/version:go_default_library",
         "@com_github_davecgh_go_spew//spew:go_default_library",
@@ -19,7 +18,6 @@ go_library(
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_hashicorp_go_multierror//:go_default_library",
         "@io_istio_api//:go_default_library",
         "@io_k8s_api//apps/v1beta1:go_default_library",
         "@io_k8s_api//batch/v1:go_default_library",

--- a/platform/kube/inject/configmap.go
+++ b/platform/kube/inject/configmap.go
@@ -48,15 +48,27 @@ func GetMeshConfig(kube kubernetes.Interface, namespace,
 		return nil, nil, fmt.Errorf("missing configuration map key %q", ConfigMapKey)
 	}
 
+	var user proxyconfig.MeshConfig
+	if err = model.ApplyYAML(yaml, &user); err != nil {
+		return nil, nil, multierror.Prefix(err, "failed to convert to proto.")
+	}
+	userProxyConfigYAML, err := model.ToYAML(user.DefaultConfig)
+	if err != nil {
+		return nil, nil, multierror.Prefix(err, "failed to re-encode default proxy config")
+	}
+
 	mesh := proxy.DefaultMeshConfig()
 	if err = model.ApplyYAML(yaml, &mesh); err != nil {
 		return nil, nil, multierror.Prefix(err, "failed to convert to proto.")
 	}
-
+	defaultProxyConfig := proxy.DefaultProxyConfig()
+	mesh.DefaultConfig = &defaultProxyConfig
+	if err = model.ApplyYAML(userProxyConfigYAML, user.DefaultConfig); err != nil {
+		return nil, nil, multierror.Prefix(err, "failed to convert to proto.")
+	}
 	if err = model.ValidateMeshConfig(&mesh); err != nil {
 		return nil, nil, err
 	}
-
 	return config, &mesh, nil
 }
 

--- a/platform/kube/inject/configmap.go
+++ b/platform/kube/inject/configmap.go
@@ -52,19 +52,23 @@ func GetMeshConfig(kube kubernetes.Interface, namespace,
 	if err = model.ApplyYAML(yaml, &user); err != nil {
 		return nil, nil, multierror.Prefix(err, "failed to convert to proto.")
 	}
-	userProxyConfigYAML, err := model.ToYAML(user.DefaultConfig)
-	if err != nil {
-		return nil, nil, multierror.Prefix(err, "failed to re-encode default proxy config")
+	var userProxyConfigYAML string
+	if user.DefaultConfig != nil {
+		userProxyConfigYAML, err = model.ToYAML(user.DefaultConfig)
+		if err != nil {
+			return nil, nil, multierror.Prefix(err, "failed to re-encode default proxy config")
+		}
 	}
-
 	mesh := proxy.DefaultMeshConfig()
 	if err = model.ApplyYAML(yaml, &mesh); err != nil {
 		return nil, nil, multierror.Prefix(err, "failed to convert to proto.")
 	}
 	defaultProxyConfig := proxy.DefaultProxyConfig()
 	mesh.DefaultConfig = &defaultProxyConfig
-	if err = model.ApplyYAML(userProxyConfigYAML, user.DefaultConfig); err != nil {
-		return nil, nil, multierror.Prefix(err, "failed to convert to proto.")
+	if userProxyConfigYAML != "" {
+		if err = model.ApplyYAML(userProxyConfigYAML, user.DefaultConfig); err != nil {
+			return nil, nil, multierror.Prefix(err, "failed to convert to proto.")
+		}
 	}
 	if err = model.ValidateMeshConfig(&mesh); err != nil {
 		return nil, nil, err

--- a/proxy/BUILD
+++ b/proxy/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//model:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_hashicorp_go_multierror//:go_default_library",
         "@io_istio_api//:go_default_library",
         "@org_golang_x_time//rate:go_default_library",
     ],

--- a/proxy/context_test.go
+++ b/proxy/context_test.go
@@ -15,6 +15,7 @@
 package proxy_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -77,5 +78,24 @@ func TestDefaultMeshConfig(t *testing.T) {
 	mesh := proxy.DefaultMeshConfig()
 	if err := model.ValidateMeshConfig(&mesh); err != nil {
 		t.Errorf("validation of default mesh config failed with %v", err)
+	}
+}
+
+func TestApplyMeshConfigDefaults(t *testing.T) {
+	configPath := "/test/config/patch"
+	yaml := fmt.Sprintf(`
+defaultConfig:
+  configPath: %s
+`, configPath)
+
+	want := proxy.DefaultMeshConfig()
+	want.DefaultConfig.ConfigPath = configPath
+
+	got, err := proxy.ApplyMeshConfigDefaults(yaml)
+	if err != nil {
+		t.Fatalf("ApplyMeshConfigDefaults() failed: %v", err)
+	}
+	if !reflect.DeepEqual(got, &want) {
+		t.Fatalf("Wrong default values:\n got %#v \nwant %#v", got, &want)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`ProxyConfig` defaults are not applied properly to user defined configuration. The current code applies defaults by decoding the user supplied MeshConfig YAML into a MeshConfig protobuf with expected default values. This works for top-level fields in the protobuf but breaks with nested pointer types, i.e. `ProxyConfig`. 

The fix implemented here uses the same strategy but explicitly applies it to the nested ProxyConfig after the top-level configuration is decoded.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
