### PR TITLE
pilot - update to bazel version 0.5.3 or later

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -1,5 +1,5 @@
 # Build instructions
 
 See [Istio Development](https://github.com/istio/istio/blob/master/devel/README.md) for build instructions. Specific points for Istio/Pilot development:
-* We use   [0.5.2](https://github.com/bazelbuild/bazel/releases/tag/0.5.2) version of Bazel.
+* We use   [0.5.3](https://github.com/bazelbuild/bazel/releases/tag/0.5.3) or later version of Bazel.
 * To perform the initial setup of the project, we run `make setup`. It installs the required tools and  [vendorizes](https://golang.org/cmd/go/#hdr-Vendor_Directories) the dependencies.


### PR DESCRIPTION
as 0.5.2 doesn't work, hit the following:  

root@linsvm:~/workspace/src/istio.io/pilot# ./bin/init.sh 
++ pwd
+ PDIR=/root/workspace/src/istio.io/pilot
+ '[' /root/workspace/src/istio.io/pilot '!=' /root/workspace/src/istio.io/pilot ']'
+ bazel build //...
ERROR: /root/workspace/src/istio.io/pilot/test/grpcecho/BUILD:4:1: no such package '@com_github_google_protobuf//': Error downloading [https://github.com/google/protobuf/archive/v3.2.0.tar.gz] to /root/.cache/bazel/_bazel_root/1f24f37de2c6e5f62ca533b368d79765/external/com_github_google_protobuf/v3.2.0.tar.gz: Checksum was a839d3f1519ff9d68ab908de5a0f269650ef1fc501c10f6eefd4cae51d29b86f but wanted 2a25c2b71c707c5552ec9afdfb22532a93a339e1ca5d38f163fe4107af08c54c and referenced by '//test/grpcecho:go_default_library_protos'.
ERROR: Analysis of target '//test/client:client' failed; build aborted.
INFO: Elapsed time: 11.732s

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
NA
