### PR TITLE
Updating protobuf archive checksum

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -450,7 +450,7 @@ go_repository(
 
 http_archive(
     name = "com_github_google_protobuf",
-    sha256 = "2a25c2b71c707c5552ec9afdfb22532a93a339e1ca5d38f163fe4107af08c54c",
+    sha256 = "a839d3f1519ff9d68ab908de5a0f269650ef1fc501c10f6eefd4cae51d29b86f",
     strip_prefix = "protobuf-3.2.0",
     url = "https://github.com/google/protobuf/archive/v3.2.0.tar.gz",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -448,11 +448,10 @@ go_repository(
     importpath = "github.com/golang/protobuf",
 )
 
-http_archive(
+git_repository(
     name = "com_github_google_protobuf",
-    sha256 = "a839d3f1519ff9d68ab908de5a0f269650ef1fc501c10f6eefd4cae51d29b86f",
-    strip_prefix = "protobuf-3.2.0",
-    url = "https://github.com/google/protobuf/archive/v3.2.0.tar.gz",
+    commit = "593e917c176b5bc5aafa57bf9f6030d749d91cd5",  # Jan 2017 3.2.0
+    remote = "https://github.com/google/protobuf.git",
 )
 
 go_repository(


### PR DESCRIPTION
The checksum of  https://github.com/google/protobuf/archive/v3.2.0.tar.gz changed under us. Probably because protobuf team rebuilt the package.

It seems it happened before 
https://github.com/google/protobuf/issues/3087

```release-note
``` 
