### PR TITLE
Egress routing fix

### DIFF
--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -722,6 +722,7 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule,
 		externalTrafficCluster = buildOriginalDSTCluster(name, mesh.ConnectTimeout)
 		externalTrafficCluster.ServiceName = key
 		externalTrafficCluster.hostname = destination
+		externalTrafficCluster.port = port
 		if protocolToHandle == model.ProtocolHTTPS {
 			externalTrafficCluster.SSLContext = &SSLContextExternal{}
 		}

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -711,7 +711,6 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule,
 
 	if rule.UseEgressProxy {
 		externalTrafficCluster = buildOutboundCluster("istio-egress", port, nil)
-		externalTrafficCluster.ServiceName = ""
 		externalTrafficCluster.Type = ClusterTypeStrictDNS
 		externalTrafficCluster.Hosts = []Host{{URL: fmt.Sprintf("tcp://%s", mesh.EgressProxyAddress)}}
 	} else {
@@ -721,6 +720,7 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule,
 		key := svc.Key(port, nil)
 		name := fmt.Sprintf("%x", sha1.Sum([]byte(key)))
 		externalTrafficCluster = buildOriginalDSTCluster(name, mesh.ConnectTimeout)
+		externalTrafficCluster.ServiceName = key
 
 		if protocolToHandle == model.ProtocolHTTPS {
 			externalTrafficCluster.SSLContext = &SSLContextExternal{}

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -721,7 +721,7 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule,
 		name := fmt.Sprintf("%x", sha1.Sum([]byte(key)))
 		externalTrafficCluster = buildOriginalDSTCluster(name, mesh.ConnectTimeout)
 		externalTrafficCluster.ServiceName = key
-
+		externalTrafficCluster.hostname = destination
 		if protocolToHandle == model.ProtocolHTTPS {
 			externalTrafficCluster.SSLContext = &SSLContextExternal{}
 		}

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -15,6 +15,7 @@
 package envoy
 
 import (
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -222,7 +223,7 @@ func buildSidecarListenersClusters(
 	if mesh.ProxyHttpPort > 0 {
 		// only HTTP outbound clusters are needed
 		httpOutbound := buildOutboundHTTPRoutes(mesh, node, instances, services, config)
-		httpOutbound = buildEgressFromSidecarHTTPRoutes(mesh, config.EgressRules(), httpOutbound)
+		httpOutbound = buildEgressFromSidecarHTTPRoutes(mesh, instances, config, httpOutbound)
 		clusters = append(clusters,
 			httpOutbound.clusters()...)
 		listeners = append(listeners,
@@ -239,23 +240,23 @@ func buildSidecarListenersClusters(
 // TODO: this can be optimized by querying for a specific HTTP port in the table
 func buildRDSRoute(mesh *proxyconfig.MeshConfig, node proxy.Node, routeName string,
 	discovery model.ServiceDiscovery, config model.IstioConfigStore) *HTTPRouteConfig {
-	var configs HTTPRouteConfigs
+	var httpConfigs HTTPRouteConfigs
 	switch node.Type {
 	case proxy.Ingress:
-		configs, _ = buildIngressRoutes(mesh, discovery, config)
+		httpConfigs, _ = buildIngressRoutes(mesh, discovery, config)
 	case proxy.Egress:
-		configs = buildEgressRoutes(mesh, discovery)
+		httpConfigs = buildEgressRoutes(mesh, discovery)
 	case proxy.Sidecar:
 		instances := discovery.HostInstances(map[string]bool{node.IPAddress: true})
 		services := discovery.Services()
-		configs = buildOutboundHTTPRoutes(mesh, node, instances, services, config)
-		configs = buildEgressFromSidecarHTTPRoutes(mesh, config.EgressRules(), configs)
+		httpConfigs = buildOutboundHTTPRoutes(mesh, node, instances, services, config)
+		httpConfigs = buildEgressFromSidecarHTTPRoutes(mesh, instances, config, httpConfigs)
 	default:
 		return nil
 	}
 
 	if routeName == RDSAll {
-		return configs.combine()
+		return httpConfigs.combine()
 	}
 
 	port, err := strconv.Atoi(routeName)
@@ -263,7 +264,7 @@ func buildRDSRoute(mesh *proxyconfig.MeshConfig, node proxy.Node, routeName stri
 		return nil
 	}
 
-	return configs[port]
+	return httpConfigs[port]
 }
 
 // buildHTTPListener constructs a listener for the network interface address and port.
@@ -404,7 +405,7 @@ func buildOutboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node, in
 
 	// note that outbound HTTP routes are supplied through RDS
 	httpOutbound := buildOutboundHTTPRoutes(mesh, sidecar, instances, services, config)
-	httpOutbound = buildEgressFromSidecarHTTPRoutes(mesh, config.EgressRules(), httpOutbound)
+	httpOutbound = buildEgressFromSidecarHTTPRoutes(mesh, instances, config, httpOutbound)
 
 	for port, routeConfig := range httpOutbound {
 		listeners = append(listeners,
@@ -698,14 +699,15 @@ func appendPortToDomains(domains []string, port int) []string {
 }
 
 func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule,
-	mesh *proxyconfig.MeshConfig, port *model.Port) *VirtualHost {
+	mesh *proxyconfig.MeshConfig, port *model.Port, instances []*model.ServiceInstance,
+	config model.IstioConfigStore) *VirtualHost {
 	var externalTrafficCluster *Cluster
+	destination := rule.Destination.Service
 
 	protocolToHandle := port.Protocol
 	if protocolToHandle == model.ProtocolGRPC {
 		protocolToHandle = model.ProtocolHTTP2
 	}
-	protocolSuffix := "-" + strings.ToLower(string(protocolToHandle))
 
 	if rule.UseEgressProxy {
 		externalTrafficCluster = buildOutboundCluster("istio-egress", port, nil)
@@ -713,7 +715,12 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule,
 		externalTrafficCluster.Type = ClusterTypeStrictDNS
 		externalTrafficCluster.Hosts = []Host{{URL: fmt.Sprintf("tcp://%s", mesh.EgressProxyAddress)}}
 	} else {
-		externalTrafficCluster = buildOriginalDSTCluster("orig-dst-cluster"+protocolSuffix, mesh.ConnectTimeout)
+		// Create a unique orig dst cluster for each service defined by egress rule
+		// So that we can apply circuit breakers, outlier detections, etc., later.
+		svc := model.Service{Hostname: destination}
+		key := svc.Key(port, nil)
+		name := fmt.Sprintf("%x", sha1.Sum([]byte(key)))
+		externalTrafficCluster = buildOriginalDSTCluster(name, mesh.ConnectTimeout)
 
 		if protocolToHandle == model.ProtocolHTTPS {
 			externalTrafficCluster.SSLContext = &SSLContextExternal{}
@@ -724,21 +731,38 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule,
 		}
 	}
 
-	externalTrafficRoute := buildDefaultRoute(externalTrafficCluster)
+	if protocolToHandle == model.ProtocolHTTPS {
+		// temporarily set the protocol to HTTP because we require applications
+		// to use http to talk to external services (and we do TLS origination).
+		// buildDestinationHTTPRoutes does not generate route blocks for HTTPS services
+		port.Protocol = model.ProtocolHTTP
+	}
 
-	domain := rule.Destination.Service
-	virtualHostName := domain + ":" + strconv.Itoa(port.Port)
+	routes := buildDestinationHTTPRoutes(&model.Service{Hostname: destination}, port, instances, config)
+	// reset the protocol to the original value
+	port.Protocol = protocolToHandle
+
+	if len(routes) > 0 {
+		// Set the destination clusters to the cluster we computed above.
+		// Services defined via egress rules do not have labels and hence no weighted clusters
+		for _, route := range routes {
+			route.Cluster = externalTrafficCluster.Name
+			route.clusters = []*Cluster{externalTrafficCluster}
+		}
+	}
+
+	virtualHostName := destination + ":" + strconv.Itoa(port.Port)
 	return &VirtualHost{
 		Name:    virtualHostName,
-		Domains: appendPortToDomains([]string{domain}, port.Port),
-		Routes:  []*HTTPRoute{externalTrafficRoute},
+		Domains: appendPortToDomains([]string{destination}, port.Port),
+		Routes:  routes,
 	}
 }
 
-func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.MeshConfig, egressRules map[string]*proxyconfig.EgressRule,
-	httpConfigs HTTPRouteConfigs) HTTPRouteConfigs {
+func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.MeshConfig, instances []*model.ServiceInstance,
+	config model.IstioConfigStore, httpConfigs HTTPRouteConfigs) HTTPRouteConfigs {
 
-	egressRules, errs := model.RejectConflictingEgressRules(egressRules)
+	egressRules, errs := model.RejectConflictingEgressRules(config.EgressRules())
 
 	if errs != nil {
 		glog.Warningf("Rejected rules: %v", errs)
@@ -752,10 +776,11 @@ func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.MeshConfig, egressRules 
 				continue
 			}
 			intPort := int(port.Port)
-			modelPort := &model.Port{Name: "external-traffic-port", Port: intPort, Protocol: protocol}
+			modelPort := &model.Port{Name: fmt.Sprintf("external-%v-%d", protocol, intPort),
+				Port: intPort, Protocol: protocol}
 			httpConfig := httpConfigs.EnsurePort(intPort)
 			httpConfig.VirtualHosts = append(httpConfig.VirtualHosts,
-				buildEgressFromSidecarVirtualHostOnPort(rule, mesh, modelPort))
+				buildEgressFromSidecarVirtualHostOnPort(rule, mesh, modelPort, instances, config))
 		}
 	}
 

--- a/proxy/envoy/config_test.go
+++ b/proxy/envoy/config_test.go
@@ -219,14 +219,16 @@ func TestTCPRouteConfigByRoute(t *testing.T) {
 const (
 	envoyConfig = "testdata/envoy.json"
 
-	cbPolicy           = "testdata/cb-policy.yaml.golden"
-	timeoutRouteRule   = "testdata/timeout-route-rule.yaml.golden"
-	weightedRouteRule  = "testdata/weighted-route.yaml.golden"
-	faultRouteRule     = "testdata/fault-route.yaml.golden"
-	redirectRouteRule  = "testdata/redirect-route.yaml.golden"
-	rewriteRouteRule   = "testdata/rewrite-route.yaml.golden"
-	websocketRouteRule = "testdata/websocket-route.yaml.golden"
-	egressRule         = "testdata/egress-rule.yaml.golden"
+	cbPolicy              = "testdata/cb-policy.yaml.golden"
+	timeoutRouteRule      = "testdata/timeout-route-rule.yaml.golden"
+	weightedRouteRule     = "testdata/weighted-route.yaml.golden"
+	faultRouteRule        = "testdata/fault-route.yaml.golden"
+	redirectRouteRule     = "testdata/redirect-route.yaml.golden"
+	rewriteRouteRule      = "testdata/rewrite-route.yaml.golden"
+	websocketRouteRule    = "testdata/websocket-route.yaml.golden"
+	egressRule            = "testdata/egress-rule.yaml.golden"
+	egressRuleCBPolicy    = "testdata/egress-rule-cb-policy.yaml.golden"
+	egressRuleTimeoutRule = "testdata/egress-rule-timeout-route-rule.yaml.golden"
 )
 
 func addConfig(r model.ConfigStore, file string, t *testing.T) {

--- a/proxy/envoy/discovery_test.go
+++ b/proxy/envoy/discovery_test.go
@@ -148,6 +148,10 @@ func TestClusterDiscoveryCircuitBreaker(t *testing.T) {
 	// add weighted rule to split into two clusters
 	addConfig(registry, weightedRouteRule, t)
 	addConfig(registry, cbPolicy, t)
+	// add egress rule and a circuit breaker for external service (*.google.com)
+	addConfig(registry, egressRule, t)
+	addConfig(registry, egressRuleCBPolicy, t)
+
 	url := fmt.Sprintf("/v1/clusters/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
 	response := makeDiscoveryRequest(ds, "GET", url, t)
 	compareResponse(response, "testdata/cds-circuit-breaker.json", t)
@@ -221,7 +225,9 @@ func TestRouteDiscoveryV1(t *testing.T) {
 
 func TestRouteDiscoveryTimeout(t *testing.T) {
 	_, registry, ds := commonSetup(t)
+	addConfig(registry, egressRule, t)
 	addConfig(registry, timeoutRouteRule, t)
+	addConfig(registry, egressRuleTimeoutRule, t)
 	url := fmt.Sprintf("/v1/routes/80/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
 	response := makeDiscoveryRequest(ds, "GET", url, t)
 	compareResponse(response, "testdata/rds-timeout.json", t)

--- a/proxy/envoy/policy.go
+++ b/proxy/envoy/policy.go
@@ -21,6 +21,7 @@ import (
 	proxyconfig "istio.io/api/proxy/v1/config"
 	"istio.io/pilot/model"
 	"istio.io/pilot/proxy"
+	"fmt"
 )
 
 // applyClusterPolicy assumes an outbound cluster and inserts custom configuration for the cluster
@@ -32,6 +33,7 @@ func applyClusterPolicy(cluster *Cluster,
 	duration := protoDurationToMS(mesh.ConnectTimeout)
 	cluster.ConnectTimeoutMs = duration
 
+	fmt.Printf("processing cluster %v\n", cluster)
 	// skip remaining policies for non mesh-local outbound clusters
 	if !cluster.outbound {
 		return

--- a/proxy/envoy/policy.go
+++ b/proxy/envoy/policy.go
@@ -21,7 +21,6 @@ import (
 	proxyconfig "istio.io/api/proxy/v1/config"
 	"istio.io/pilot/model"
 	"istio.io/pilot/proxy"
-	"fmt"
 )
 
 // applyClusterPolicy assumes an outbound cluster and inserts custom configuration for the cluster
@@ -33,7 +32,6 @@ func applyClusterPolicy(cluster *Cluster,
 	duration := protoDurationToMS(mesh.ConnectTimeout)
 	cluster.ConnectTimeoutMs = duration
 
-	fmt.Printf("processing cluster %v\n", cluster)
 	// skip remaining policies for non mesh-local outbound clusters
 	if !cluster.outbound {
 		return

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -333,5 +333,6 @@ func buildOriginalDSTCluster(name string, timeout *duration.Duration) *Cluster {
 		Type:             ClusterTypeOriginalDST,
 		ConnectTimeoutMs: protoDurationToMS(timeout),
 		LbType:           LbTypeOriginalDST,
+		outbound:         true,
 	}
 }

--- a/proxy/envoy/testdata/cds-circuit-breaker.json.golden
+++ b/proxy/envoy/testdata/cds-circuit-breaker.json.golden
@@ -72,7 +72,21 @@
     "connect_timeout_ms": 1000,
     "type": "original_dst",
     "lb_type": "original_dst_lb",
-    "features": "http2"
+    "max_requests_per_connection": 9,
+    "features": "http2",
+    "circuit_breakers": {
+     "default": {
+      "max_connections": 9,
+      "max_pending_requests": 9,
+      "max_requests": 9
+     }
+    },
+    "outlier_detection": {
+     "consecutive_5xx": 9,
+     "interval_ms": 9000,
+     "base_ejection_time_ms": 9000,
+     "max_ejection_percent": 9
+    }
    },
    {
     "name": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
@@ -86,7 +100,21 @@
     "service_name": "*.google.com|external-HTTP-80",
     "connect_timeout_ms": 1000,
     "type": "original_dst",
-    "lb_type": "original_dst_lb"
+    "lb_type": "original_dst_lb",
+    "max_requests_per_connection": 9,
+    "circuit_breakers": {
+     "default": {
+      "max_connections": 9,
+      "max_pending_requests": 9,
+      "max_requests": 9
+     }
+    },
+    "outlier_detection": {
+     "consecutive_5xx": 9,
+     "interval_ms": 9000,
+     "base_ejection_time_ms": 9000,
+     "max_ejection_percent": 9
+    }
    },
    {
     "name": "out.242bc3028e0f3fe0682e6d972e167ab415b2321d",
@@ -105,7 +133,21 @@
     "connect_timeout_ms": 1000,
     "type": "original_dst",
     "lb_type": "original_dst_lb",
-    "ssl_context": {}
+    "max_requests_per_connection": 9,
+    "ssl_context": {},
+    "circuit_breakers": {
+     "default": {
+      "max_connections": 9,
+      "max_pending_requests": 9,
+      "max_requests": 9
+     }
+    },
+    "outlier_detection": {
+     "consecutive_5xx": 9,
+     "interval_ms": 9000,
+     "base_ejection_time_ms": 9000,
+     "max_ejection_percent": 9
+    }
    },
    {
     "name": "out.5898aa4379cc19c8f1bb3b7915ee8e0e32ddc6a6",

--- a/proxy/envoy/testdata/cds-circuit-breaker.json.golden
+++ b/proxy/envoy/testdata/cds-circuit-breaker.json.golden
@@ -127,19 +127,19 @@
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "random",
-    "max_requests_per_connection": 100,
+    "max_requests_per_connection": 9,
     "circuit_breakers": {
      "default": {
-      "max_connections": 100,
-      "max_pending_requests": 100,
-      "max_requests": 100
+      "max_connections": 9,
+      "max_pending_requests": 9,
+      "max_requests": 9
      }
     },
     "outlier_detection": {
-     "consecutive_5xx": 10,
-     "interval_ms": 30000,
-     "base_ejection_time_ms": 15500,
-     "max_ejection_percent": 100
+     "consecutive_5xx": 9,
+     "interval_ms": 9000,
+     "base_ejection_time_ms": 9000,
+     "max_ejection_percent": 9
     }
    },
    {
@@ -180,19 +180,19 @@
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "random",
-    "max_requests_per_connection": 100,
+    "max_requests_per_connection": 9,
     "circuit_breakers": {
      "default": {
-      "max_connections": 100,
-      "max_pending_requests": 100,
-      "max_requests": 100
+      "max_connections": 9,
+      "max_pending_requests": 9,
+      "max_requests": 9
      }
     },
     "outlier_detection": {
-     "consecutive_5xx": 10,
-     "interval_ms": 30000,
-     "base_ejection_time_ms": 15500,
-     "max_ejection_percent": 100
+     "consecutive_5xx": 9,
+     "interval_ms": 9000,
+     "base_ejection_time_ms": 9000,
+     "max_ejection_percent": 9
     }
    },
    {

--- a/proxy/envoy/testdata/cds-circuit-breaker.json.golden
+++ b/proxy/envoy/testdata/cds-circuit-breaker.json.golden
@@ -169,19 +169,19 @@
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "random",
-    "max_requests_per_connection": 9,
+    "max_requests_per_connection": 100,
     "circuit_breakers": {
      "default": {
-      "max_connections": 9,
-      "max_pending_requests": 9,
-      "max_requests": 9
+      "max_connections": 100,
+      "max_pending_requests": 100,
+      "max_requests": 100
      }
     },
     "outlier_detection": {
-     "consecutive_5xx": 9,
-     "interval_ms": 9000,
-     "base_ejection_time_ms": 9000,
-     "max_ejection_percent": 9
+     "consecutive_5xx": 10,
+     "interval_ms": 30000,
+     "base_ejection_time_ms": 15500,
+     "max_ejection_percent": 100
     }
    },
    {
@@ -222,19 +222,19 @@
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "random",
-    "max_requests_per_connection": 9,
+    "max_requests_per_connection": 100,
     "circuit_breakers": {
      "default": {
-      "max_connections": 9,
-      "max_pending_requests": 9,
-      "max_requests": 9
+      "max_connections": 100,
+      "max_pending_requests": 100,
+      "max_requests": 100
      }
     },
     "outlier_detection": {
-     "consecutive_5xx": 9,
-     "interval_ms": 9000,
-     "base_ejection_time_ms": 9000,
-     "max_ejection_percent": 9
+     "consecutive_5xx": 10,
+     "interval_ms": 30000,
+     "base_ejection_time_ms": 15500,
+     "max_ejection_percent": 100
     }
    },
    {

--- a/proxy/envoy/testdata/cds-circuit-breaker.json.golden
+++ b/proxy/envoy/testdata/cds-circuit-breaker.json.golden
@@ -67,11 +67,26 @@
     ]
    },
    {
+    "name": "out.02875f9311443c8773650d3fa21cee271505806f",
+    "service_name": "*.google.com|external-HTTP2-8080",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb",
+    "features": "http2"
+   },
+   {
     "name": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
     "service_name": "world.default.svc.cluster.local|mongo",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"
+   },
+   {
+    "name": "out.241817cc0b7d464b36565d486ed22d9494b67a27",
+    "service_name": "*.google.com|external-HTTP-80",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
    },
    {
     "name": "out.242bc3028e0f3fe0682e6d972e167ab415b2321d",
@@ -83,6 +98,14 @@
       "url": "tcp://localhost:8888"
      }
     ]
+   },
+   {
+    "name": "out.55be44fb22f17cf2c3204372ebee71e7723bcb1c",
+    "service_name": "*.google.com|external-HTTPS-443",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb",
+    "ssl_context": {}
    },
    {
     "name": "out.5898aa4379cc19c8f1bb3b7915ee8e0e32ddc6a6",

--- a/proxy/envoy/testdata/cds-ssl-context.json.golden
+++ b/proxy/envoy/testdata/cds-ssl-context.json.golden
@@ -67,6 +67,14 @@
     ]
    },
    {
+    "name": "out.02875f9311443c8773650d3fa21cee271505806f",
+    "service_name": "*.google.com|external-HTTP2-8080",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb",
+    "features": "http2"
+   },
+   {
     "name": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
     "service_name": "world.default.svc.cluster.local|mongo",
     "connect_timeout_ms": 1000,
@@ -81,6 +89,13 @@
       "spiffe://cluster.local/ns/default/sa/serviceaccount2"
      ]
     }
+   },
+   {
+    "name": "out.241817cc0b7d464b36565d486ed22d9494b67a27",
+    "service_name": "*.google.com|external-HTTP-80",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
    },
    {
     "name": "out.242bc3028e0f3fe0682e6d972e167ab415b2321d",
@@ -98,6 +113,14 @@
      "ca_cert_file": "/etc/certs/root-cert.pem",
      "verify_subject_alt_name": []
     }
+   },
+   {
+    "name": "out.55be44fb22f17cf2c3204372ebee71e7723bcb1c",
+    "service_name": "*.google.com|external-HTTPS-443",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb",
+    "ssl_context": {}
    },
    {
     "name": "out.5898aa4379cc19c8f1bb3b7915ee8e0e32ddc6a6",
@@ -215,26 +238,6 @@
      "ca_cert_file": "/etc/certs/root-cert.pem",
      "verify_subject_alt_name": []
     }
-   },
-   {
-    "name": "out.orig-dst-cluster-http",
-    "connect_timeout_ms": 1000,
-    "type": "original_dst",
-    "lb_type": "original_dst_lb"
-   },
-   {
-    "name": "out.orig-dst-cluster-http2",
-    "connect_timeout_ms": 1000,
-    "type": "original_dst",
-    "lb_type": "original_dst_lb",
-    "features": "http2"
-   },
-   {
-    "name": "out.orig-dst-cluster-https",
-    "connect_timeout_ms": 1000,
-    "type": "original_dst",
-    "lb_type": "original_dst_lb",
-    "ssl_context": {}
    },
    {
     "name": "mixer_server",

--- a/proxy/envoy/testdata/egress-rule-cb-policy.yaml.golden
+++ b/proxy/envoy/testdata/egress-rule-cb-policy.yaml.golden
@@ -1,6 +1,7 @@
 type: destination-policy
 name: egress-circuit-breaker
 namespace: default
+domain: cluster.local
 spec:
   source:
     name: hello

--- a/proxy/envoy/testdata/egress-rule-cb-policy.yaml.golden
+++ b/proxy/envoy/testdata/egress-rule-cb-policy.yaml.golden
@@ -10,13 +10,13 @@ spec:
     service: "*.google.com"
   circuitBreaker:
     simpleCb:
-      maxConnections: 100
-      sleepWindow: 15.5s
-      httpMaxRequests: 100
-      httpMaxRequestsPerConnection: 100
-      httpMaxPendingRequests: 100
-      httpConsecutiveErrors: 10
-      httpDetectionInterval: 30s
-      httpMaxEjectionPercent: 100
+      maxConnections: 9
+      sleepWindow: 9s
+      httpMaxRequests: 9
+      httpMaxRequestsPerConnection: 9
+      httpMaxPendingRequests: 9
+      httpConsecutiveErrors: 9
+      httpDetectionInterval: 9s
+      httpMaxEjectionPercent: 9
   loadBalancing:
     name: RANDOM

--- a/proxy/envoy/testdata/egress-rule-cb-policy.yaml.golden
+++ b/proxy/envoy/testdata/egress-rule-cb-policy.yaml.golden
@@ -1,0 +1,22 @@
+type: destination-policy
+name: egress-circuit-breaker
+namespace: default
+spec:
+  source:
+    name: hello
+    labels:
+      version: v0
+  destination:
+    service: "*.google.com"
+  circuitBreaker:
+    simpleCb:
+      maxConnections: 100
+      sleepWindow: 15.5s
+      httpMaxRequests: 100
+      httpMaxRequestsPerConnection: 100
+      httpMaxPendingRequests: 100
+      httpConsecutiveErrors: 10
+      httpDetectionInterval: 30s
+      httpMaxEjectionPercent: 100
+  loadBalancing:
+    name: RANDOM

--- a/proxy/envoy/testdata/egress-rule-timeout-route-rule.yaml.golden
+++ b/proxy/envoy/testdata/egress-rule-timeout-route-rule.yaml.golden
@@ -1,0 +1,13 @@
+type: route-rule
+name: egress-timeout
+namespace: default
+spec:
+  destination:
+    service: "*.google.com"
+  httpReqTimeout:
+    simpleTimeout:
+      timeout: 30s
+  httpReqRetries:
+    simple_retry:
+      attempts: 1
+      perTryTimeout: 5s

--- a/proxy/envoy/testdata/rds-httpproxy.json.golden
+++ b/proxy/envoy/testdata/rds-httpproxy.json.golden
@@ -8,7 +8,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.orig-dst-cluster-https"
+      "cluster": "out.55be44fb22f17cf2c3204372ebee71e7723bcb1c"
      }
     ]
    },
@@ -21,7 +21,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.orig-dst-cluster-http"
+      "cluster": "out.241817cc0b7d464b36565d486ed22d9494b67a27"
      }
     ]
    },
@@ -33,7 +33,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.orig-dst-cluster-http2"
+      "cluster": "out.02875f9311443c8773650d3fa21cee271505806f"
      }
     ]
    },

--- a/proxy/envoy/testdata/rds-timeout.json.golden
+++ b/proxy/envoy/testdata/rds-timeout.json.golden
@@ -1,6 +1,25 @@
 {
   "virtual_hosts": [
    {
+    "name": "*.google.com:80",
+    "domains": [
+     "*.google.com",
+     "*.google.com:80"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.241817cc0b7d464b36565d486ed22d9494b67a27",
+      "timeout_ms": 30000,
+      "retry_policy": {
+       "retry_on": "5xx,connect-failure,refused-stream",
+       "num_retries": 1,
+       "per_try_timeout_ms": 5000
+      }
+     }
+    ]
+   },
+   {
     "name": "hello.default.svc.cluster.local|http",
     "domains": [
      "hello:80",

--- a/proxy/envoy/testdata/rds-v0-nomixer.json.golden
+++ b/proxy/envoy/testdata/rds-v0-nomixer.json.golden
@@ -9,7 +9,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.orig-dst-cluster-http"
+      "cluster": "out.241817cc0b7d464b36565d486ed22d9494b67a27"
      }
     ]
    },


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable routing and destination policies for egress rules
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1180 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

Its not correct. The goldens are not getting updated properly, even though all the clusters are being added to the common pool. Worse still, running the refresh goldens command, updates the circuit breaker settings for world service!