### PR TITLE
teach istioctl non-hyphenated resource names

### DIFF
--- a/adapter/config/crd/client.go
+++ b/adapter/config/crd/client.go
@@ -160,7 +160,7 @@ func (cl *Client) RegisterResources() error {
 				Scope:   apiextensionsv1beta1.NamespaceScoped,
 				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 					Plural: ResourceName(schema.Plural),
-					Kind:   kabobCaseToCamelCase(schema.Type),
+					Kind:   KabobCaseToCamelCase(schema.Type),
 				},
 			},
 		}

--- a/adapter/config/crd/conversion.go
+++ b/adapter/config/crd/conversion.go
@@ -71,7 +71,7 @@ func ResourceName(s string) string {
 }
 
 // kabobCaseToCamelCase converts "my-name" to "MyName"
-func kabobCaseToCamelCase(s string) string {
+func KabobCaseToCamelCase(s string) string {
 	words := strings.Split(s, "-")
 	out := ""
 	for _, word := range words {

--- a/adapter/config/crd/conversion.go
+++ b/adapter/config/crd/conversion.go
@@ -70,7 +70,7 @@ func ResourceName(s string) string {
 	return strings.Replace(s, "-", "", -1)
 }
 
-// kabobCaseToCamelCase converts "my-name" to "MyName"
+// KabobCaseToCamelCase converts "my-name" to "MyName"
 func KabobCaseToCamelCase(s string) string {
 	words := strings.Split(s, "-")
 	out := ""

--- a/adapter/config/crd/conversion_test.go
+++ b/adapter/config/crd/conversion_test.go
@@ -30,7 +30,7 @@ func TestCamelKabob(t *testing.T) {
 		if s != tt.out {
 			t.Errorf("CamelCaseToKabobCase(%q) => %q, want %q", tt.in, s, tt.out)
 		}
-		u := kabobCaseToCamelCase(tt.out)
+		u := KabobCaseToCamelCase(tt.out)
 		if u != tt.in {
 			t.Errorf("kabobToCamel(%q) => %q, want %q", tt.out, u, tt.in)
 		}

--- a/adapter/config/crd/generate.sh
+++ b/adapter/config/crd/generate.sh
@@ -51,7 +51,7 @@ cat << EOF
 		object: &${crd}{
 			TypeMeta: meta_v1.TypeMeta{
 				Kind:       "${crd}",
-				APIVersion: model.IstioAPIVersion,
+				APIVersion: model.IstioAPIGroup + "/" + model.IstioAPIVersion,
 			},
 		},
 		collection: &${crd}List{},
@@ -67,4 +67,3 @@ EOF
 for crd in $CRDS; do
   sed -e "1,20d;s/IstioKind/$crd/g" adapter/config/crd/config.go
 done
-

--- a/cmd/istioctl/BUILD
+++ b/cmd/istioctl/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//platform/kube:go_default_library",
         "//platform/kube/inject:go_default_library",
         "//tools/version:go_default_library",
+        "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -459,7 +459,12 @@ func printShortOutput(_ *crd.Client, configList []model.Config) {
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
 	fmt.Fprintf(&w, "NAME\tKIND\tNAMESPACE\n")
 	for _, c := range configList {
-		fmt.Fprintf(&w, "%s\t%s\t%s\n", c.Name, c.Type, c.Namespace)
+		kind := fmt.Sprintf("%s.%s.%s",
+			crd.KabobCaseToCamelCase(c.Type),
+			model.IstioAPIVersion,
+			model.IstioAPIGroup,
+		)
+		fmt.Fprintf(&w, "%s\t%s\t%s\n", c.Name, kind, c.Namespace)
 	}
 	w.Flush() // nolint: errcheck
 }

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -344,7 +344,8 @@ func schema(configClient *crd.Client, typ string) (model.ProtoSchema, error) {
 	for _, desc := range configClient.ConfigDescriptor() {
 		switch typ {
 		case desc.Type, desc.Plural: // legacy hyphenated resources names
-			return desc, nil
+			return model.ProtoSchema{}, fmt.Errorf("%q not recognized. Please use non-hyphenated resource name %q",
+				typ, crd.ResourceName(typ))
 		case crd.ResourceName(desc.Type), crd.ResourceName(desc.Plural):
 			return desc, nil
 		}

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -165,13 +165,13 @@ and destination policies.
 		Short: "Retrieve policies and rules",
 		Example: `
 		# List all route rules
-		istioctl get route-rules
+		istioctl get routerules
 
 		# List all destination policies
-		istioctl get destination-policies
+		istioctl get destinationpolicies
 
 		# Get a specific rule named productpage-default
-		istioctl get route-rule productpage-default
+		istioctl get routerule productpage-default
 		`,
 		RunE: func(c *cobra.Command, args []string) error {
 			configClient, err := newClient()
@@ -231,7 +231,7 @@ and destination policies.
 		istioctl delete -f example-routing.yaml
 
 		# Delete the rule productpage-default
-		istioctl delete route-rule productpage-default
+		istioctl delete routerule productpage-default
 		`,
 		RunE: func(c *cobra.Command, args []string) error {
 			configClient, errs := newClient()
@@ -340,7 +340,7 @@ func main() {
 	}
 }
 
-// The schema is based on the kind (for example "route-rule" or "destination-policy")
+// The schema is based on the kind (for example "routerule" or "destinationpolicy")
 func schema(configClient *crd.Client, typ string) (model.ProtoSchema, error) {
 	for _, desc := range configClient.ConfigDescriptor() {
 		switch typ {
@@ -393,7 +393,7 @@ func readInputs() ([]model.Config, error) {
 func readInputsKubectl(reader io.Reader) ([]model.Config, error) {
 	var varr []model.Config
 
-	// We store route-rules as a YaML stream; there may be more than one decoder.
+	// We store routerules as a YaML stream; there may be more than one decoder.
 	yamlDecoder := kubeyaml.NewYAMLOrJSONDecoder(reader, 512*1024)
 	for {
 		obj := crd.IstioKind{}
@@ -432,7 +432,7 @@ func readInputsKubectl(reader io.Reader) ([]model.Config, error) {
 func readInputsLegacy(reader io.Reader) ([]model.Config, error) {
 	var varr []model.Config
 
-	// We store route-rules as a YaML stream; there may be more than one decoder.
+	// We store routerules as a YaML stream; there may be more than one decoder.
 	yamlDecoder := kubeyaml.NewYAMLOrJSONDecoder(reader, 512*1024)
 	for {
 		v := model.JSONConfig{}

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -362,12 +362,14 @@ func schema(configClient *crd.Client, typ string) (model.ProtoSchema, error) {
 // readInputs reads multiple documents from the input and checks with the schema
 func readInputs() ([]model.Config, error) {
 	var reader io.Reader
-	if file == "" {
+	switch file {
+	case "":
+		return nil, errors.New("filename not specified (see --filename or -f)")
+	case "-":
 		reader = os.Stdin
-	} else {
+	default:
 		var err error
-		reader, err = os.Open(file)
-		if err != nil {
+		if reader, err = os.Open(file); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -466,17 +466,17 @@ func printYamlOutput(configClient *crd.Client, configList []model.Config) {
 	for _, config := range configList {
 		schema, exists := descriptor.GetByType(config.Type)
 		if !exists {
-			fmt.Errorf("Unknown kind %q for %v", crd.ResourceName(config.Type), config.Name)
+			glog.Errorf("Unknown kind %q for %v", crd.ResourceName(config.Type), config.Name)
 			continue
 		}
 		obj, err := crd.ConvertConfig(schema, config)
 		if err != nil {
-			fmt.Errorf("Could not decode %v: %v", config.Name, err)
+			glog.Errorf("Could not decode %v: %v", config.Name, err)
 			continue
 		}
 		bytes, err := yaml.Marshal(obj)
 		if err != nil {
-			fmt.Errorf("Could not convert %v to YAML: %v", config, err)
+			glog.Errorf("Could not convert %v to YAML: %v", config, err)
 			continue
 		}
 		fmt.Print(string(bytes))

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -375,9 +375,9 @@ func readInputs() ([]model.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if out, err := readInputsLegacy(bytes.NewReader(input)); err == nil {
-		return out, nil
-	}
+	// if out, err := readInputsLegacy(bytes.NewReader(input)); err == nil {
+	// 	return out, nil
+	// }
 	return readInputsKubectl(bytes.NewReader(input))
 }
 
@@ -426,6 +426,7 @@ func readInputsKubectl(reader io.Reader) ([]model.Config, error) {
 
 // readInputsLegacy reads multiple documents from the input and checks
 // with the schema.
+// nolint: deadcode, megacheck
 func readInputsLegacy(reader io.Reader) ([]model.Config, error) {
 	var varr []model.Config
 

--- a/platform/kube/BUILD
+++ b/platform/kube/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//model:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
-        "@io_istio_api//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
@@ -51,7 +50,6 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//model:go_default_library",
-        "//proxy:go_default_library",
         "//test/util:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

Teach istioctl non-hyphenated resource names for proxy CRD types, e.g. `istioctl get routerules`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes https://github.com/istio/pilot/issues/1236

**Special notes for your reviewer**:

Question: support for hyphenated names is still retained. Shall we remove that to avoid being stuck with multiple naming variants? 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
