### PR TITLE
Improve model coverage and remove legacy istioctl input

### DIFF
--- a/adapter/config/crd/BUILD
+++ b/adapter/config/crd/BUILD
@@ -23,6 +23,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/serializer:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/yaml:go_default_library",
         "@io_k8s_apimachinery//pkg/watch:go_default_library",
         "@io_k8s_client_go//plugin/pkg/client/auth/gcp:go_default_library",
         "@io_k8s_client_go//plugin/pkg/client/auth/oidc:go_default_library",

--- a/cmd/istioctl/BUILD
+++ b/cmd/istioctl/BUILD
@@ -23,7 +23,6 @@ go_library(
         "@com_github_spf13_cobra//:go_default_library",
         "@com_github_spf13_cobra//doc:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/yaml:go_default_library",
     ],
 )
 

--- a/model/conversion_test.go
+++ b/model/conversion_test.go
@@ -48,14 +48,14 @@ func TestProtoSchemaConversions(t *testing.T) {
 		"route": [
 		{
 			"destination": {
-                "name" : "bar"
-            },
+				"name" : "bar"
+			},
 			"weight": 75
 		},
 		{
 			"destination": {
-                "name" : "baz"
-            },
+				"name" : "baz"
+			},
 			"weight": 25
 		}
 		]
@@ -94,33 +94,6 @@ func TestProtoSchemaConversions(t *testing.T) {
 		},
 	}
 
-	wantJSONConfig := model.JSONConfig{
-		ConfigMeta: model.ConfigMeta{
-			Type: model.RouteRule.Type,
-			Name: "test",
-		},
-		Spec: wantJSONMap,
-	}
-
-	wantYAMLConfig := "name: test\n" +
-		"spec:\n" +
-		"  destination:\n" +
-		"    name: foo\n" +
-		"  precedence: 5\n" +
-		"  route:\n" +
-		"  - destination:\n" +
-		"      name: bar\n" +
-		"    weight: 75\n" +
-		"  - destination:\n" +
-		"      name: baz\n" +
-		"    weight: 25\n" +
-		"type: route-rule\n"
-
-	wantConfig := model.Config{
-		ConfigMeta: wantJSONConfig.ConfigMeta,
-		Spec:       msg,
-	}
-
 	badSchema := &model.ProtoSchema{MessageName: "bad-name"}
 	if _, err := badSchema.FromYAML(wantYAML); err == nil {
 		t.Errorf("FromYAML should have failed using ProtoSchema with bad MessageName")
@@ -134,6 +107,10 @@ func TestProtoSchemaConversions(t *testing.T) {
 
 	if gotJSON != strings.Join(strings.Fields(wantJSON), "") {
 		t.Errorf("ToJSON failed: got %s, want %s", gotJSON, wantJSON)
+	}
+
+	if _, err = model.ToJSON(nil); err == nil {
+		t.Error("should produce an error")
 	}
 
 	gotFromJSON, err := routeRuleSchema.FromJSON(wantJSON)
@@ -156,6 +133,10 @@ func TestProtoSchemaConversions(t *testing.T) {
 		t.Errorf("ToYAML failed: got %+v want %+v", spew.Sdump(gotYAML), spew.Sdump(wantYAML))
 	}
 
+	if _, err = model.ToYAML(nil); err == nil {
+		t.Error("should produce an error")
+	}
+
 	gotFromYAML, err := routeRuleSchema.FromYAML(wantYAML)
 
 	if err != nil {
@@ -164,6 +145,10 @@ func TestProtoSchemaConversions(t *testing.T) {
 
 	if !reflect.DeepEqual(gotFromYAML, msg) {
 		t.Errorf("FromYAML failed: got %+v want %+v", spew.Sdump(gotFromYAML), spew.Sdump(msg))
+	}
+
+	if _, err = routeRuleSchema.FromYAML(":"); err == nil {
+		t.Errorf("should produce an error")
 	}
 
 	gotJSONMap, err := model.ToJSONMap(msg)
@@ -176,6 +161,10 @@ func TestProtoSchemaConversions(t *testing.T) {
 		t.Errorf("ToJSONMap failed: \ngot %vwant %v", spew.Sdump(gotJSONMap), spew.Sdump(wantJSONMap))
 	}
 
+	if _, err = model.ToJSONMap(nil); err == nil {
+		t.Error("should produce an error")
+	}
+
 	gotFromJSONMap, err := routeRuleSchema.FromJSONMap(wantJSONMap)
 
 	if err != nil {
@@ -186,41 +175,11 @@ func TestProtoSchemaConversions(t *testing.T) {
 		t.Errorf("FromJSONMap failed: got %+v want %+v", spew.Sdump(gotFromJSONMap), spew.Sdump(msg))
 	}
 
-	gotFromJSONConfig, err := model.IstioConfigTypes.FromJSON(wantJSONConfig)
-
-	if err != nil {
-		t.Errorf("FromJSON failed: %v", err)
+	if _, err = routeRuleSchema.FromJSONMap(1); err == nil {
+		t.Error("should produce an error")
 	}
 
-	if !reflect.DeepEqual(gotFromJSONConfig, &wantConfig) {
-		t.Errorf("FromJSON failed: got %+v want %+v", spew.Sdump(gotFromJSONConfig), spew.Sdump(wantConfig))
-	}
-
-	gotFromYAMLConfig, err := model.IstioConfigTypes.FromYAML([]byte(wantYAMLConfig))
-
-	if err != nil {
-		t.Errorf("FromYAML failed: %v", err)
-	}
-
-	if !reflect.DeepEqual(gotFromYAMLConfig, &wantConfig) {
-		t.Errorf("FromYAML failed: got %+v want %+v", spew.Sdump(gotFromYAMLConfig), spew.Sdump(wantConfig))
-	}
-
-	gotFromConfig, err := model.IstioConfigTypes.ToYAML(wantConfig)
-
-	if err != nil {
-		t.Errorf("ToYAML failed: %v", err)
-	}
-
-	if gotFromConfig != wantYAMLConfig {
-		t.Errorf("ToYAML failed: got %s want %s", gotFromConfig, wantYAMLConfig)
-	}
-
-	if _, err = model.IstioConfigTypes.ToYAML(model.Config{}); err == nil {
-		t.Error("ToYAML failed: want error")
-	}
-
-	if _, err = model.IstioConfigTypes.FromJSON(model.JSONConfig{}); err == nil {
-		t.Error("FromJSON failed: want error")
+	if _, err = routeRuleSchema.FromJSON(":"); err == nil {
+		t.Errorf("should produce an error")
 	}
 }

--- a/model/validation.go
+++ b/model/validation.go
@@ -602,6 +602,9 @@ func ValidateThrottle(throttle *proxyconfig.L4FaultInjection_Throttle) (errs err
 
 // ValidateLoadBalancing validates Load Balancing
 func ValidateLoadBalancing(lb *proxyconfig.LoadBalancing) (errs error) {
+	if lb.LbPolicy == nil {
+		errs = multierror.Append(errs, errors.New("must set load balancing if specified"))
+	}
 	// Currently the policy is just a name, and we don't validate it
 	return
 }

--- a/proxy/envoy/discovery_test.go
+++ b/proxy/envoy/discovery_test.go
@@ -322,7 +322,7 @@ func TestRouteDiscoveryIstioEgress(t *testing.T) {
 func TestSidecarListenerDiscovery(t *testing.T) {
 	testCases := []struct {
 		name string
-		file string
+		file fileConfig
 	}{
 		{name: "none"},
 		/* these configs do not affect listeners
@@ -365,7 +365,7 @@ func TestSidecarListenerDiscovery(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			_, registry, ds := commonSetup(t)
 
-			if testCase.file != "" {
+			if testCase.name != "none" {
 				addConfig(registry, testCase.file, t)
 			}
 

--- a/proxy/envoy/ingress_test.go
+++ b/proxy/envoy/ingress_test.go
@@ -9,10 +9,7 @@ import (
 	"istio.io/pilot/model"
 )
 
-const (
-	ingressRouteRule1 = "testdata/ingress-route-world.yaml.golden"
-	ingressRouteRule2 = "testdata/ingress-route-foo.yaml.golden"
-)
+const ()
 
 func addIngressRoutes(r model.ConfigStore, t *testing.T) {
 	addConfig(r, ingressRouteRule1, t)

--- a/proxy/envoy/ingress_test.go
+++ b/proxy/envoy/ingress_test.go
@@ -9,8 +9,6 @@ import (
 	"istio.io/pilot/model"
 )
 
-const ()
-
 func addIngressRoutes(r model.ConfigStore, t *testing.T) {
 	addConfig(r, ingressRouteRule1, t)
 	addConfig(r, ingressRouteRule2, t)

--- a/proxy/envoy/testdata/cb-policy.yaml.golden
+++ b/proxy/envoy/testdata/cb-policy.yaml.golden
@@ -1,25 +1,20 @@
-type: destination-policy
-name: circuit-breaker
-namespace: default
-domain: cluster.local
-spec:
-  source:
-    name: hello
-    labels:
-      version: v0
-  destination:
-    name: world
-    labels:
-      version: v0
-  circuitBreaker:
-    simpleCb:
-      maxConnections: 100
-      sleepWindow: 15.5s
-      httpMaxRequests: 100
-      httpMaxRequestsPerConnection: 100
-      httpMaxPendingRequests: 100
-      httpConsecutiveErrors: 10
-      httpDetectionInterval: 30s
-      httpMaxEjectionPercent: 100
-  loadBalancing:
-    name: RANDOM
+source:
+  name: hello
+  labels:
+    version: v0
+destination:
+  name: world
+  labels:
+    version: v0
+circuitBreaker:
+  simpleCb:
+    maxConnections: 100
+    sleepWindow: 15.5s
+    httpMaxRequests: 100
+    httpMaxRequestsPerConnection: 100
+    httpMaxPendingRequests: 100
+    httpConsecutiveErrors: 10
+    httpDetectionInterval: 30s
+    httpMaxEjectionPercent: 100
+loadBalancing:
+  name: RANDOM

--- a/proxy/envoy/testdata/egress-rule-cb-policy.yaml.golden
+++ b/proxy/envoy/testdata/egress-rule-cb-policy.yaml.golden
@@ -1,23 +1,18 @@
-type: destination-policy
-name: egress-circuit-breaker
-namespace: default
-domain: cluster.local
-spec:
-  source:
-    name: hello
-    labels:
-      version: v0
-  destination:
-    service: "*.google.com"
-  circuitBreaker:
-    simpleCb:
-      maxConnections: 9
-      sleepWindow: 9s
-      httpMaxRequests: 9
-      httpMaxRequestsPerConnection: 9
-      httpMaxPendingRequests: 9
-      httpConsecutiveErrors: 9
-      httpDetectionInterval: 9s
-      httpMaxEjectionPercent: 9
-  loadBalancing:
-    name: RANDOM
+source:
+  name: hello
+  labels:
+    version: v0
+destination:
+  service: "*.google.com"
+circuitBreaker:
+  simpleCb:
+    maxConnections: 9
+    sleepWindow: 9s
+    httpMaxRequests: 9
+    httpMaxRequestsPerConnection: 9
+    httpMaxPendingRequests: 9
+    httpConsecutiveErrors: 9
+    httpDetectionInterval: 9s
+    httpMaxEjectionPercent: 9
+loadBalancing:
+  name: RANDOM

--- a/proxy/envoy/testdata/egress-rule-timeout-route-rule.yaml.golden
+++ b/proxy/envoy/testdata/egress-rule-timeout-route-rule.yaml.golden
@@ -1,13 +1,9 @@
-type: route-rule
-name: egress-timeout
-namespace: default
-spec:
-  destination:
-    service: "*.google.com"
-  httpReqTimeout:
-    simpleTimeout:
-      timeout: 30s
-  httpReqRetries:
-    simple_retry:
-      attempts: 1
-      perTryTimeout: 5s
+destination:
+  service: "*.google.com"
+httpReqTimeout:
+  simpleTimeout:
+    timeout: 30s
+httpReqRetries:
+  simple_retry:
+    attempts: 1
+    perTryTimeout: 5s

--- a/proxy/envoy/testdata/egress-rule.yaml.golden
+++ b/proxy/envoy/testdata/egress-rule.yaml.golden
@@ -1,13 +1,9 @@
-type: egress-rule
-name: myegress
-namespace: default
-spec:
-  destination:
-    service: "*.google.com"
-  ports:
-  - port: 80
-    protocol: http
-  - port: 443
-    protocol: https
-  - port: 8080
-    protocol: http2
+destination:
+  service: "*.google.com"
+ports:
+- port: 80
+  protocol: http
+- port: 443
+  protocol: https
+- port: 8080
+  protocol: http2

--- a/proxy/envoy/testdata/fault-route.yaml.golden
+++ b/proxy/envoy/testdata/fault-route.yaml.golden
@@ -1,30 +1,25 @@
-type: route-rule
-name: fault-route
-namespace: default
-domain: cluster.local
-spec:
-  destination:
-    name: world
-  match:
-    source:
-      name: hello
-      labels:
-        version: v0
-    request:
-      headers:
-        scooby:
-          exact: doo
-        animal:
-          prefix: dog.cat
-        name:
-          regex: "sco+do+"
-  route:
-    - labels:
-         version: v1
-  httpFault:
-    delay:
-      percent: 100
-      fixed_delay: 5s
-    abort:
-      percent: 100
-      http_status: 503
+destination:
+  name: world
+match:
+  source:
+    name: hello
+    labels:
+      version: v0
+  request:
+    headers:
+      scooby:
+        exact: doo
+      animal:
+        prefix: dog.cat
+      name:
+        regex: "sco+do+"
+route:
+  - labels:
+       version: v1
+httpFault:
+  delay:
+    percent: 100
+    fixed_delay: 5s
+  abort:
+    percent: 100
+    http_status: 503

--- a/proxy/envoy/testdata/ingress-route-foo.yaml.golden
+++ b/proxy/envoy/testdata/ingress-route-foo.yaml.golden
@@ -1,14 +1,9 @@
-type: ingress-rule
-name: foo
-namespace: default
-domain: cluster.local
-spec:
-  destination:
-    name: hello
-  destinationPort: 81
-  tlsSecret: my-secret.default
-  match:
-    request:
-      headers:
-        uri:
-          prefix: "/bar"
+destination:
+  name: hello
+destinationPort: 81
+tlsSecret: my-secret.default
+match:
+  request:
+    headers:
+      uri:
+        prefix: "/bar"

--- a/proxy/envoy/testdata/ingress-route-world.yaml.golden
+++ b/proxy/envoy/testdata/ingress-route-world.yaml.golden
@@ -1,15 +1,10 @@
-type: ingress-rule
-name: bar
-namespace: default
-domain: cluster.local
-spec:
-  destination:
-    name: world
-  destinationPortName: http
-  match:
-    request:
-      headers:
-        authority:
-          exact: world.com
-        uri:
-          exact: "/hello"
+destination:
+  name: world
+destinationPortName: http
+match:
+  request:
+    headers:
+      authority:
+        exact: world.com
+      uri:
+        exact: "/hello"

--- a/proxy/envoy/testdata/redirect-route.yaml.golden
+++ b/proxy/envoy/testdata/redirect-route.yaml.golden
@@ -1,20 +1,15 @@
-type: route-rule
-name: redirect-route
-namespace: default
-domain: cluster.local
-spec:
-  destination:
-    name: world
-  match:
-    request:
-      headers:
-        scooby:
-          exact: doo
-        animal:
-          prefix: dog
-        name:
-          regex: "sco+do+"
-  redirect:
-    uri: "/new/path"
-    authority: "foo.bar.com"
+destination:
+  name: world
+match:
+  request:
+    headers:
+      scooby:
+        exact: doo
+      animal:
+        prefix: dog
+      name:
+        regex: "sco+do+"
+redirect:
+  uri: "/new/path"
+  authority: "foo.bar.com"
 

--- a/proxy/envoy/testdata/rewrite-route.yaml.golden
+++ b/proxy/envoy/testdata/rewrite-route.yaml.golden
@@ -1,16 +1,11 @@
-type: route-rule
-name: rewrite-route
-namespace: default
-domain: cluster.local
-spec:
-  destination:
-    name: world
-  match:
-    request:
-      headers:
-        uri:
-          prefix: /old/path
-  rewrite:
-    uri: /new/path
-    authority: foo.bar.com
+destination:
+  name: world
+match:
+  request:
+    headers:
+      uri:
+        prefix: /old/path
+rewrite:
+  uri: /new/path
+  authority: foo.bar.com
 

--- a/proxy/envoy/testdata/timeout-route-rule.yaml.golden
+++ b/proxy/envoy/testdata/timeout-route-rule.yaml.golden
@@ -1,14 +1,9 @@
-type: route-rule
-name: timeout
-namespace: default
-domain: cluster.local
-spec:
-  destination:
-    name: world
-  httpReqTimeout:
-    simpleTimeout:
-      timeout: 30s
-  httpReqRetries:
-    simple_retry:
-      attempts: 1
-      perTryTimeout: 5s
+destination:
+  name: world
+httpReqTimeout:
+  simpleTimeout:
+    timeout: 30s
+httpReqRetries:
+  simple_retry:
+    attempts: 1
+    perTryTimeout: 5s

--- a/proxy/envoy/testdata/websocket-route.yaml.golden
+++ b/proxy/envoy/testdata/websocket-route.yaml.golden
@@ -1,13 +1,8 @@
-type: route-rule
-name: websocket-route
-namespace: default
-domain: cluster.local
-spec:
-  destination:
-    name: hello
-  match:
-    request:
-      headers:
-        uri:
-          prefix: /websocket
-  websocketUpgrade: True
+destination:
+  name: hello
+match:
+  request:
+    headers:
+      uri:
+        prefix: /websocket
+websocketUpgrade: True

--- a/proxy/envoy/testdata/weighted-route.yaml.golden
+++ b/proxy/envoy/testdata/weighted-route.yaml.golden
@@ -1,14 +1,9 @@
-type: route-rule
-name: weighted-route
-namespace: default
-domain: cluster.local
-spec:
-  destination:
-    name: world
-  route:
-    - labels:
-         version: v0
-      weight: 75
-    - labels:
-         version: v1
-      weight: 25
+destination:
+  name: world
+route:
+  - labels:
+       version: v0
+    weight: 75
+  - labels:
+       version: v1
+    weight: 25

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -201,7 +201,7 @@ func (proxy envoy) args(fname string, epoch int) []string {
 func (proxy envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 	envoyConfig, ok := config.(*Config)
 	if !ok {
-		return fmt.Errorf("Unexpected config type: %#v", config)
+		return fmt.Errorf("unexpected config type: %#v", config)
 	}
 
 	// create parent directories if necessary

--- a/test/integration/testdata/rule-content-route.yaml.tmpl
+++ b/test/integration/testdata/rule-content-route.yaml.tmpl
@@ -1,6 +1,7 @@
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
-name: content-route
+metadata:
+  name: content-route
 spec:
   destination:
     name: c

--- a/test/integration/testdata/rule-content-route.yaml.tmpl
+++ b/test/integration/testdata/rule-content-route.yaml.tmpl
@@ -1,4 +1,5 @@
-type: route-rule
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
 name: content-route
 spec:
   destination:

--- a/test/integration/testdata/rule-default-route.yaml.tmpl
+++ b/test/integration/testdata/rule-default-route.yaml.tmpl
@@ -1,6 +1,7 @@
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
-name: default-route
+metadata:
+  name: default-route
 spec:
   destination:
     name: c

--- a/test/integration/testdata/rule-default-route.yaml.tmpl
+++ b/test/integration/testdata/rule-default-route.yaml.tmpl
@@ -1,4 +1,5 @@
-type: route-rule
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
 name: default-route
 spec:
   destination:

--- a/test/integration/testdata/rule-fault-injection.yaml.tmpl
+++ b/test/integration/testdata/rule-fault-injection.yaml.tmpl
@@ -1,4 +1,5 @@
-type: route-rule
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
 name: fault-route
 spec:
   destination:

--- a/test/integration/testdata/rule-fault-injection.yaml.tmpl
+++ b/test/integration/testdata/rule-fault-injection.yaml.tmpl
@@ -1,6 +1,7 @@
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
-name: fault-route
+metadata:
+  name: fault-route
 spec:
   destination:
     name: c

--- a/test/integration/testdata/rule-redirect-injection.yaml.tmpl
+++ b/test/integration/testdata/rule-redirect-injection.yaml.tmpl
@@ -1,4 +1,5 @@
-type: route-rule
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
 name: redirect-route
 spec:
   destination:

--- a/test/integration/testdata/rule-redirect-injection.yaml.tmpl
+++ b/test/integration/testdata/rule-redirect-injection.yaml.tmpl
@@ -1,6 +1,7 @@
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
-name: redirect-route
+metadata:
+  name: redirect-route
 spec:
   destination:
     name: c

--- a/test/integration/testdata/rule-regex-route.yaml.tmpl
+++ b/test/integration/testdata/rule-regex-route.yaml.tmpl
@@ -1,6 +1,7 @@
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
-name: content-route
+metadata:
+  name: content-route
 spec:
   destination:
     name: c

--- a/test/integration/testdata/rule-regex-route.yaml.tmpl
+++ b/test/integration/testdata/rule-regex-route.yaml.tmpl
@@ -1,4 +1,5 @@
-type: route-rule
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
 name: content-route
 spec:
   destination:

--- a/test/integration/testdata/rule-websocket-route.yaml.tmpl
+++ b/test/integration/testdata/rule-websocket-route.yaml.tmpl
@@ -1,6 +1,7 @@
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
-name: websocket-route
+metadata:
+  name: websocket-route
 spec:
   destination:
     name: c

--- a/test/integration/testdata/rule-websocket-route.yaml.tmpl
+++ b/test/integration/testdata/rule-websocket-route.yaml.tmpl
@@ -1,4 +1,5 @@
-type: route-rule
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
 name: websocket-route
 spec:
   destination:

--- a/test/integration/testdata/rule-weighted-route.yaml.tmpl
+++ b/test/integration/testdata/rule-weighted-route.yaml.tmpl
@@ -1,6 +1,7 @@
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
-name: default-route
+metadata:
+  name: default-route
 spec:
   destination:
     name: c

--- a/test/integration/testdata/rule-weighted-route.yaml.tmpl
+++ b/test/integration/testdata/rule-weighted-route.yaml.tmpl
@@ -1,4 +1,5 @@
-type: route-rule
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
 name: default-route
 spec:
   destination:


### PR DESCRIPTION
**What this PR does / why we need it**:
Follows up https://github.com/istio/pilot/pull/1280 with updating internal test configuration to kubectl format.

Improves coverage in model package.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
