### PR TITLE
correct url of lyft.github.io to envoyproxy.github.io and correct con…

### DIFF
--- a/doc/proxy-redirection-configuration.md
+++ b/doc/proxy-redirection-configuration.md
@@ -17,7 +17,7 @@ An attacker impact is minimized if envoy is compromised with non-elevated privil
 ## Configuration for redirection inbound and outbound traffic to proxy
 
 The following assumes all inbound and outbound traffic is redirected (via iptables) to a single port. The envoy process binds to this port and uses SO_ORIGINAL_DST to recover the original destination and pass on to the matching filter (see 
-[config-listeners](https://lyft.github.io/envoy/docs/configuration/listeners/listeners.html#config-listeners)).
+[config-listeners](https://envoyproxy.github.io/envoy/configuration/listeners/listeners.html)).
 ```
 ISTIO_PROXY_PORT=5001
 ```

--- a/proxy/agent.go
+++ b/proxy/agent.go
@@ -35,7 +35,7 @@ import (
 // successfully launch a new Envoy process that will replace the running Envoy
 // processes, the restart epoch of the new process must be exactly 1 greater
 // than the highest restart epoch of the currently running Envoy processes.
-// See https://lyft.github.io/envoy/docs/intro/arch_overview/hot_restart.html
+// See https://envoyproxy.github.io/envoy/intro/arch_overview/hot_restart.html
 // for more information about the Envoy hot restart protocol.
 //
 // Agent requires two functions "run" and "cleanup". Run function is a call to

--- a/proxy/envoy/discovery.go
+++ b/proxy/envoy/discovery.go
@@ -243,7 +243,7 @@ func (ds *DiscoveryService) Register(container *restful.Container) {
 		Doc("Services in SDS"))
 
 	// This route makes discovery act as an Envoy Service discovery service (SDS).
-	// See https://lyft.github.io/envoy/docs/intro/arch_overview/service_discovery.html#arch-overview-service-discovery-sds
+	// See https://envoyproxy.github.io/envoy/intro/arch_overview/service_discovery.html#service-discovery-service-sds
 	ws.Route(ws.
 		GET(fmt.Sprintf("/v1/registration/{%s}", ServiceKey)).
 		To(ds.ListEndpoints).
@@ -251,7 +251,7 @@ func (ds *DiscoveryService) Register(container *restful.Container) {
 		Param(ws.PathParameter(ServiceKey, "tuple of service name and tag name").DataType("string")))
 
 	// This route makes discovery act as an Envoy Cluster discovery service (CDS).
-	// See https://lyft.github.io/envoy/docs/configuration/cluster_manager/cds.html
+	// See https://envoyproxy.github.io/envoy/configuration/cluster_manager/cds.html#config-cluster-manager-cds
 	ws.Route(ws.
 		GET(fmt.Sprintf("/v1/clusters/{%s}/{%s}", ServiceCluster, ServiceNode)).
 		To(ds.ListClusters).

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -159,7 +159,7 @@ type HTTPTraceDriverConfig struct {
 }
 
 // RootRuntime definition.
-// See: https://lyft.github.io/envoy/docs/configuration/overview/overview.html
+// See https://envoyproxy.github.io/envoy/configuration/overview/overview.html
 type RootRuntime struct {
 	SymlinkRoot          string `json:"symlink_root"`
 	Subdirectory         string `json:"subdirectory"`
@@ -290,7 +290,7 @@ type RetryPolicy struct {
 }
 
 // WeightedCluster definition
-// See https://lyft.github.io/envoy/docs/configuration/http_conn_man/route_config/route.html
+// See https://envoyproxy.github.io/envoy/configuration/http_conn_man/route_config/route.html
 type WeightedCluster struct {
 	Clusters         []*WeightedClusterEntry `json:"clusters"`
 	RuntimeKeyPrefix string                  `json:"runtime_key_prefix,omitempty"`


### PR DESCRIPTION
What this PR does / why we need it:

With this PR, fix the issues about the URLs, URLs  of `lyft.github.io` have been changed to `envoyproxy.github.io`, and some of the headline permalinks have also been changed. 

Which issue this PR fixes:
No issue have been created yet, this PR is created directly to correct the URLs.

Special notes for your reviewer:

Release note:
Signed-off-by: linzhinan <linzhinan@huawei.com>