### PR TITLE
use cloud.google.com instead of www.google.com in egress test

### DIFF
--- a/test/integration/egress.go
+++ b/test/integration/egress.go
@@ -57,7 +57,7 @@ func (t *egress) setup() error {
 		},
 		Spec: v1.ServiceSpec{
 			Type:         "ExternalName",
-			ExternalName: "www.google.com",
+			ExternalName: "cloud.google.com",
 			Ports: []v1.ServicePort{{
 				Port: 443,
 				Name: "https", // important to define protocol


### PR DESCRIPTION
**What this PR does / why we need it**:
in countries other than US, www.google.com redirects to local versions
of google e.g. www.google.co.il, www.google.de etc.

**Which issue this PR fixes** *(optional, in `fixes 

this redirection fails the egress test. cloud.google.com does not redirect and works OK outside of US

#<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```