### PR TITLE
bugfix: remove istio initializer from istio-system workloads

### DIFF
--- a/platform/kube/inject/initializer.go
+++ b/platform/kube/inject/initializer.go
@@ -172,12 +172,6 @@ func (i *Initializer) initialize(in interface{}, patcher patcherFunc) error {
 namespaceSearch:
 	for _, namespace := range i.config.Namespaces {
 		if namespace == v1.NamespaceAll {
-			// skip special kubernetes system namespaces
-			for _, namespace := range ignoredNamespaces {
-				if obj.GetNamespace() == namespace {
-					break namespaceSearch
-				}
-			}
 			inject = true
 			break namespaceSearch
 		} else if namespace == obj.GetNamespace() {

--- a/platform/kube/inject/inject.go
+++ b/platform/kube/inject/inject.go
@@ -446,6 +446,13 @@ func intoObject(c *Config, in interface{}) (interface{}, error) {
 		return nil, err
 	}
 
+	// skip special kubernetes system namespaces
+	for _, namespace := range ignoredNamespaces {
+		if obj.GetNamespace() == namespace {
+			return out, nil
+		}
+	}
+
 	if !injectRequired(c.Policy, obj) {
 		glog.V(2).Infof("Skipping %s/%s due to policy check", obj.GetNamespace(), obj.GetName())
 		return out, nil


### PR DESCRIPTION
istio-system namespace is handled differently than normal user
namespaces and should not have sidecar's injected. This fixes a bug in
that logic where the sidecar was not injected (correct) but the
pending list of initializers was not cleared (bug). This caused
istio-system components to not be deployed in cluster-wide
installations to istio-system name.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
