### PR TITLE
Revert "Use regex field instead of overloading header match for regex routes"

### DIFF
--- a/adapter/config/ingress/conversion.go
+++ b/adapter/config/ingress/conversion.go
@@ -104,9 +104,7 @@ func createIngressRule(name, host, path, domainSuffix string,
 			}
 		} else {
 			rule.Match.Request.Headers[model.HeaderURI] = &proxyconfig.StringMatch{
-				// Always do prefix match for ingress paths
-				// as thats what the standard kubernetes nginx ingress does.
-				MatchType: &proxyconfig.StringMatch_Prefix{Prefix: path},
+				MatchType: &proxyconfig.StringMatch_Exact{Exact: path},
 			}
 		}
 	}

--- a/proxy/envoy/header.go
+++ b/proxy/envoy/header.go
@@ -26,7 +26,6 @@ import (
 func buildHTTPRouteMatch(matches *proxyconfig.MatchCondition) *HTTPRoute {
 	path := ""
 	prefix := "/"
-	regex := ""
 	var headers Headers
 	if matches != nil && matches.Request != nil {
 		for name, match := range matches.Request.Headers {
@@ -36,15 +35,11 @@ func buildHTTPRouteMatch(matches *proxyconfig.MatchCondition) *HTTPRoute {
 				case *proxyconfig.StringMatch_Exact:
 					path = m.Exact
 					prefix = ""
-					regex = ""
 				case *proxyconfig.StringMatch_Prefix:
 					path = ""
 					prefix = m.Prefix
-					regex = ""
 				case *proxyconfig.StringMatch_Regex:
-					path = ""
-					prefix = ""
-					regex = m.Regex
+					headers = append(headers, buildHeader(name, match))
 				}
 			} else {
 				headers = append(headers, buildHeader(name, match))
@@ -55,7 +50,6 @@ func buildHTTPRouteMatch(matches *proxyconfig.MatchCondition) *HTTPRoute {
 	return &HTTPRoute{
 		Path:    path,
 		Prefix:  prefix,
-		Regex:   regex,
 		Headers: headers,
 	}
 }

--- a/proxy/envoy/header_test.go
+++ b/proxy/envoy/header_test.go
@@ -29,7 +29,7 @@ func TestHTTPMatch(t *testing.T) {
 	}{
 		{
 			in:   &proxyconfig.MatchCondition{},
-			want: &HTTPRoute{Path: "", Prefix: "/", Regex: ""},
+			want: &HTTPRoute{Path: "", Prefix: "/"},
 		},
 		{
 			in: &proxyconfig.MatchCondition{
@@ -39,7 +39,7 @@ func TestHTTPMatch(t *testing.T) {
 					},
 				},
 			},
-			want: &HTTPRoute{Path: "/path", Prefix: "", Regex: ""},
+			want: &HTTPRoute{Path: "/path", Prefix: ""},
 		},
 		{
 			in: &proxyconfig.MatchCondition{
@@ -49,7 +49,7 @@ func TestHTTPMatch(t *testing.T) {
 					},
 				},
 			},
-			want: &HTTPRoute{Path: "", Prefix: "/prefix", Regex: ""},
+			want: &HTTPRoute{Path: "", Prefix: "/prefix"},
 		},
 		{
 			in: &proxyconfig.MatchCondition{
@@ -59,7 +59,9 @@ func TestHTTPMatch(t *testing.T) {
 					},
 				},
 			},
-			want: &HTTPRoute{Path: "", Prefix: "", Regex: "/.*"},
+			want: &HTTPRoute{Path: "", Prefix: "/", Headers: Headers{
+				{Name: model.HeaderURI, Value: "/.*", Regex: true},
+			}},
 		},
 		{
 			in: &proxyconfig.MatchCondition{
@@ -71,9 +73,10 @@ func TestHTTPMatch(t *testing.T) {
 					},
 				},
 			},
-			want: &HTTPRoute{Path: "", Prefix: "", Regex: "/.*", Headers: Headers{
+			want: &HTTPRoute{Path: "", Prefix: "/", Headers: Headers{
 				{Name: "cookie", Value: "^user=jason\\?.*", Regex: true},
 				{Name: "test", Value: "value"},
+				{Name: model.HeaderURI, Value: "/.*", Regex: true},
 			}},
 		},
 	}

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -219,7 +219,6 @@ type HTTPRoute struct {
 
 	Path   string `json:"path,omitempty"`
 	Prefix string `json:"prefix,omitempty"`
-	Regex  string `json:"regex,omitempty"`
 
 	PrefixRewrite string `json:"prefix_rewrite,omitempty"`
 	HostRewrite   string `json:"host_rewrite,omitempty"`


### PR DESCRIPTION
Reverts istio/pilot#1291 until it's ready and safe to introduce to the release branch.