### PR TITLE
Make release script runnable locally

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -27,7 +27,9 @@ if [ ! "${TAG_NAME}" ] ; then
   usage
 fi
 
-# Build environment setup
+# Cloud Builder checks out code in /workspace.
+# We need to recreate the GOPATH directory structure
+# for pilot to build correctly
 function prepare_gopath() {
   [[ -z ${GOPATH} ]] && export GOPATH=/tmp/gopath
   mkdir -p ${GOPATH}/src/istio.io

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -28,10 +28,17 @@ if [ ! "${TAG_NAME}" ] ; then
 fi
 
 # Build environment setup
-mkdir -p /tmp/gopath/src/istio.io
-ln -s /workspace /tmp/gopath/src/istio.io/pilot
-cd /tmp/gopath/src/istio.io/pilot
-touch platform/kube/config
+function prepare_gopath() {
+  [[ -z ${GOPATH} ]] && export GOPATH=/tmp/gopath
+  mkdir -p ${GOPATH}/src/istio.io
+  [[ -d ${GOPATH}/src/istio.io/pilot ]] || ln -s ${PWD} ${GOPATH}/src/istio.io/pilot
+  cd ${GOPATH}/src/istio.io/pilot
+  touch platform/kube/config
+}
+
+if [ ${PWD} != "${GOPATH}/src/istio.io/pilot" ]; then
+  prepare_gopath
+fi
 
 # Download and set the credentials for docker.io/istio hub
 mkdir -p "${HOME}/.docker"

--- a/bin/use_bazel_go.sh
+++ b/bin/use_bazel_go.sh
@@ -1,9 +1,10 @@
 # This file should be sourced before using go commands
 # it ensures that bazel's version of go is used
 
-SP=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+ROOT=$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )
+DIR_NAME="$(basename ${ROOT})"
 
-TARGETBIN=$SP/../bazel-pilot
+TARGETBIN="${ROOT}/bazel-${DIR_NAME}"
 if [[ ! -e $TARGETBIN ]]; then
   echo "*** $TARGETBIN does not exist - did you forget to bazel build ... ?"
   exit 1


### PR DESCRIPTION
Fixes issue in use_bazel_go.sh for release.
Fixes #1310 

Changed the script to be a little more robust such that we can test it locally. Cloud Builder checks out code in /workspace, use_bazel_go assumes the codes is checked out in a pilot directory which is not true. Even so we run the build from the GOPATH, bazel will use the link target to create a bazel-workspace directory.

```release-note
none
```
