### PR TITLE
Simplify use_bazel_go with bazel info

### DIFF
--- a/bin/use_bazel_go.sh
+++ b/bin/use_bazel_go.sh
@@ -1,22 +1,18 @@
 # This file should be sourced before using go commands
 # it ensures that bazel's version of go is used
 
-ROOT=$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )
-DIR_NAME="$(basename ${ROOT})"
+EXEC_ROOT="$(bazel info execution_root)"
 
-TARGETBIN="${ROOT}/bazel-${DIR_NAME}"
-if [[ ! -e $TARGETBIN ]]; then
-  echo "*** $TARGETBIN does not exist - did you forget to bazel build ... ?"
+if [[ ! -e ${EXEC_ROOT} ]]; then
+  echo "*** ${EXEC_ROOT} does not exist - did you forget to bazel build ... ?"
   exit 1
 fi
 
-BDIR=$(dirname $(dirname $(readlink $TARGETBIN)))
-
-export GOROOT="$(find ${BDIR}/external -type d -name 'go1_*')"
-export PATH=$GOROOT/bin:$PATH
+export GOROOT="$(find ${EXEC_ROOT}/external -type d -name 'go1_*')"
+export PATH=${GOROOT}/bin:${PATH}
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   echo "*** Calling ${BASH_SOURCE[0]} directly has no effect. It should be sourced."
-  echo "Using GOROOT: $GOROOT" 
+  echo "Using GOROOT: ${GOROOT}"
   go version
 fi


### PR DESCRIPTION
As @kyessenov suggested this is less error prone.

```release-note
none
```
