### PR TITLE
Context-create command for istioctl

### DIFF
--- a/cmd/istioctl/BUILD
+++ b/cmd/istioctl/BUILD
@@ -28,6 +28,8 @@ go_library(
         "@io_k8s_client_go//discovery:go_default_library",
         "@io_k8s_client_go//dynamic:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_client_go//tools/clientcmd:go_default_library",
+        "@io_k8s_client_go//tools/clientcmd/api:go_default_library",
     ],
 )
 

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -412,7 +412,7 @@ and destination policies.
 		Short: "Create base kubeconfig file for a server",
 		Example: `
 		# Create a config file for the api server.
-		istioctl config-create 127.0.0.1:8080
+		istioctl config-create http://127.0.0.1:8080
 		`,
 		RunE: func(c *cobra.Command, args []string) error {
 
@@ -440,6 +440,7 @@ and destination policies.
 			}
 
 			pathOpts := clientcmd.NewDefaultPathOptions()
+			// use specified kubeconfig file for the location of new config
 			pathOpts.GlobalFile = kubeconfig
 			err = clientcmd.ModifyConfig(pathOpts, config, false)
 

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -409,7 +409,7 @@ and destination policies.
 	}
 
 	configCmd = &cobra.Command{
-		Use:   "context-create --api-server <ip>:<port>",
+		Use:   "context-create --api-server http://<ip>:<port>",
 		Short: "Create base kubeconfig file for a server",
 		Example: `
 		# Create a config file for the api server.

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -450,7 +450,7 @@ and destination policies.
 			config.Contexts[contextName] = context
 
 			contextSwitched := false
-			if config.CurrentContext != contextName {
+			if config.CurrentContext != "" && config.CurrentContext != contextName {
 				contextSwitched = true
 			}
 			config.CurrentContext = contextName


### PR DESCRIPTION
**What this PR does / why we need it**:
adds `config-create` command to istioctl.  Components of istio require a kubeconfig file.  To run istio in environment other than kubernetes, user would need to install and use `kubectl` to generate this file.  The new command creates/modifies the kubeconfig file so `kubectl` is not needed for non-k8s environments.  Uses k8s libraries for generation and writing to file

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
