### PR TITLE
Fix proxy agent lock-up

### DIFF
--- a/proxy/agent.go
+++ b/proxy/agent.go
@@ -214,18 +214,26 @@ func (a *agent) Run(ctx context.Context) {
 			// cleanup for the epoch
 			a.proxy.Cleanup(status.epoch)
 
-			// schedule a retry for a transient error and skip aborts
-			if status.err != nil && status.err != errAbort && !reflect.DeepEqual(a.desiredConfig, a.currentConfig) {
-				if a.retry.budget > 0 {
-					delayDuration := a.retry.InitialInterval * (1 << uint(a.retry.MaxRetries-a.retry.budget))
-					restart := time.Now().Add(delayDuration)
-					a.retry.restart = &restart
-					a.retry.budget = a.retry.budget - 1
-					glog.V(2).Infof("Updated retry delay to %v, budget to %d", delayDuration, a.retry.budget)
+			// schedule a retry for an error.
+			// the current config might be out of date from here since its proxy might have been aborted.
+			// the current config will change on abort, hence retrying prior to abort will not progress.
+			// that means that aborted envoy might need to re-schedule a retry if it was not already scheduled.
+			if status.err != nil {
+				// skip retrying twice by checking retry restart delay
+				if a.retry.restart == nil {
+					if a.retry.budget > 0 {
+						delayDuration := a.retry.InitialInterval * (1 << uint(a.retry.MaxRetries-a.retry.budget))
+						restart := time.Now().Add(delayDuration)
+						a.retry.restart = &restart
+						a.retry.budget = a.retry.budget - 1
+						glog.V(2).Infof("Epoch %d: set retry delay to %v, budget to %d", status.epoch, delayDuration, a.retry.budget)
+					} else {
+						glog.Error("Permanent error: budget exhausted trying to fulfill the desired configuration")
+						a.proxy.Panic(a.desiredConfig)
+						return
+					}
 				} else {
-					glog.Error("Permanent error: budget exhausted trying to fulfill the desired configuration")
-					a.proxy.Panic(a.desiredConfig)
-					return
+					glog.V(2).Infof("Epoch %d: restart already scheduled", status.epoch)
 				}
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The last change to the logic to abort-all envoys introduced a scenario when envoy could dead lock on rapid config changes (as is possible with firing config scheduling for the same config too often as done by the cert watcher).

This fixes the case by always reconciling on any error (abort or not). The reconciliation logic will apply in case the current config aborts immediately after reconciliation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1329 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
