### PR TITLE
Add dampening to file watcher. It will only deliver 1 event per maxDelay

### DIFF
--- a/bin/check.sh
+++ b/bin/check.sh
@@ -16,7 +16,6 @@ gometalinter --concurrency=${NUM_CPU} --enable-gc --deadline=300s --disable-all\
   --enable=golint\
   --exclude=.pb.go\
   --exclude=gen_test.go\
-  --enable=gotype\
   --enable=ineffassign\
   --enable=interfacer\
   --enable=lll --line-length=120\
@@ -33,3 +32,4 @@ gometalinter --concurrency=${NUM_CPU} --enable-gc --deadline=300s --disable-all\
 # --enable=dupl\
 # --enable=gocyclo\
 # --cyclo-over=15\
+# --enable=gotype\

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -103,7 +103,8 @@ func (w *watcher) Reload() {
 	w.agent.ScheduleConfigUpdate(config)
 }
 
-type watchFileEventsFn func(ctx context.Context, wch <-chan *fsnotify.FileEvent, maxDelay time.Duration, notifyFn func())
+type watchFileEventsFn func(ctx context.Context, wch <-chan *fsnotify.FileEvent,
+	maxDelay time.Duration, notifyFn func())
 
 // watchFileEvents watches for changes on a channel and notifies via notifyFn().
 // The function batches changes so that related changes are processed together.
@@ -143,7 +144,8 @@ func watchFileEvents(ctx context.Context, wch <-chan *fsnotify.FileEvent, maxDel
 // `updateFunc` method when changes are detected. This method is blocking
 // so it should be run as a goroutine.
 // updateFunc will not be called more than one time per maxDelay.
-func watchCerts(ctx context.Context, certsDirs []string, watchFileEventsFn watchFileEventsFn, maxDelay time.Duration, updateFunc func()) {
+func watchCerts(ctx context.Context, certsDirs []string, watchFileEventsFn watchFileEventsFn,
+	maxDelay time.Duration, updateFunc func()) {
 	fw, err := fsnotify.NewWatcher()
 	if err != nil {
 		glog.Warningf("failed to create a watcher for certificate files: %v", err)

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -68,6 +68,9 @@ func NewWatcher(config proxyconfig.ProxyConfig, agent proxy.Agent, role proxy.No
 	}
 }
 
+// defaultMaxDelay is the maximum amount of time to wait before delivering events.
+const defaultMaxDelay = 5 * time.Second
+
 func (w *watcher) Run(ctx context.Context) {
 	// agent consumes notifications from the controller
 	go w.agent.Run(ctx)
@@ -76,9 +79,12 @@ func (w *watcher) Run(ctx context.Context) {
 	w.Reload()
 
 	// monitor certificates
+	certDirs := make([]string, 0, len(w.certs))
 	for _, cert := range w.certs {
-		go watchCerts(ctx, cert.Directory, w.Reload)
+		certDirs = append(certDirs, cert.Directory)
 	}
+
+	go watchCerts(ctx, certDirs, watchFileEvents, defaultMaxDelay, w.Reload)
 
 	<-ctx.Done()
 }
@@ -97,13 +103,50 @@ func (w *watcher) Reload() {
 	w.agent.ScheduleConfigUpdate(config)
 }
 
-// watchCerts watches a certificate directory and calls the provided
+type watchFileEventsFn func(ctx context.Context, wch <-chan *fsnotify.FileEvent, maxDelay time.Duration, notifyFn func())
+
+// watchFileEvents watches for changes on a channel and notifies via notifyFn().
+// The function batches changes so that related changes are processed together.
+// The function ensures that notifyFn() is called no more than one time per maxDelay.
+// The function does not return until the the context is cancelled.
+func watchFileEvents(ctx context.Context, wch <-chan *fsnotify.FileEvent, maxDelay time.Duration, notifyFn func()) {
+	// timer and channel for managing maxDelay.
+	var timeChan <-chan time.Time
+	var timer *time.Timer
+
+	for {
+		select {
+		case ev := <-wch:
+			glog.Infof("watchFileEvents: %s", ev.String())
+			if timer != nil {
+				continue
+			}
+			// create new timer
+			timer = time.NewTimer(maxDelay)
+			timeChan = timer.C
+		case <-timeChan:
+			// reset timer
+			timeChan = nil
+			timer.Stop()
+			timer = nil
+
+			glog.Info("watchFileEvents: notifying")
+			notifyFn()
+		case <-ctx.Done():
+			glog.V(2).Info("watchFileEvents has terminated")
+			return
+		}
+	}
+}
+
+// watchCerts watches all certificate directories and calls the provided
 // `updateFunc` method when changes are detected. This method is blocking
-// so should be run as a goroutine.
-func watchCerts(ctx context.Context, certsDir string, updateFunc func()) {
+// so it should be run as a goroutine.
+// updateFunc will not be called more than one time per maxDelay.
+func watchCerts(ctx context.Context, certsDirs []string, watchFileEventsFn watchFileEventsFn, maxDelay time.Duration, updateFunc func()) {
 	fw, err := fsnotify.NewWatcher()
 	if err != nil {
-		glog.Warning("failed to create a watcher for certificate files")
+		glog.Warningf("failed to create a watcher for certificate files: %v", err)
 		return
 	}
 	defer func() {
@@ -112,22 +155,14 @@ func watchCerts(ctx context.Context, certsDir string, updateFunc func()) {
 		}
 	}()
 
-	if err := fw.Watch(certsDir); err != nil {
-		glog.Warningf("watching %s encounters an error %v", certsDir, err)
-		return
-	}
-
-	for {
-		select {
-		case <-fw.Event:
-			glog.V(2).Infof("Change to %q is detected, reload the proxy if necessary", certsDir)
-			updateFunc()
-
-		case <-ctx.Done():
-			glog.V(2).Info("Certificate watcher is terminated")
+	// watch all directories
+	for _, d := range certsDirs {
+		if err := fw.Watch(d); err != nil {
+			glog.Warningf("watching %s encounters an error %v", d, err)
 			return
 		}
 	}
+	watchFileEventsFn(ctx, fw.Event, maxDelay, updateFunc)
 }
 
 func generateCertHash(h hash.Hash, certsDir string, files []string) {

--- a/proxy/envoy/watcher_test.go
+++ b/proxy/envoy/watcher_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"flag"
 	"io/ioutil"
 	"os"
 	"path"
@@ -194,7 +193,7 @@ func TestEnvoyArgs(t *testing.T) {
 	test := envoy{config: config, node: "my-node"}
 	testProxy := NewProxy(config, "my-node")
 	if !reflect.DeepEqual(testProxy, test) {
-		t.Errorf("unexpected struct %v", testProxy)
+		t.Errorf("unexpected struct got\n%v\nwant\n%v", testProxy, test)
 	}
 
 	got := test.args("test.json", 5)
@@ -242,5 +241,3 @@ func TestEnvoyRun(t *testing.T) {
 		t.Errorf("expected error on bad config path")
 	}
 }
-
-var _ = flag.Lookup("v").Value.Set("99")

--- a/proxy/envoy/watcher_test.go
+++ b/proxy/envoy/watcher_test.go
@@ -18,12 +18,15 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"flag"
 	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/howeyc/fsnotify"
 
 	"istio.io/pilot/proxy"
 )
@@ -68,6 +71,42 @@ func TestRunReload(t *testing.T) {
 	}
 }
 
+func TestWatchCerts_Multiple(t *testing.T) {
+	called := 0
+	callback := func() {
+		called++
+	}
+
+	maxDelay := 500 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wch := make(chan *fsnotify.FileEvent, 10)
+
+	go watchFileEvents(ctx, wch, maxDelay, callback)
+
+	// fire off multiple events
+	wch <- &fsnotify.FileEvent{Name: "f1"}
+	wch <- &fsnotify.FileEvent{Name: "f2"}
+	wch <- &fsnotify.FileEvent{Name: "f3"}
+
+	// sleep for less than maxDelay
+	time.Sleep(maxDelay / 2)
+
+	// Expect no events to be delivered within maxDelay.
+	if called != 0 {
+		t.Fatalf("Called %d times, want 0", called)
+	}
+
+	// wait for quiet period
+	time.Sleep(maxDelay)
+
+	// Expect exactly 1 event to be delivered.
+	if called != 1 {
+		t.Fatalf("Called %d times, want 1", called)
+	}
+	cancel()
+}
+
 func TestWatchCerts(t *testing.T) {
 	name, err := ioutil.TempDir("testdata", "certs")
 	if err != nil {
@@ -86,7 +125,7 @@ func TestWatchCerts(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	go watchCerts(ctx, name, callbackFunc)
+	go watchCerts(ctx, []string{name}, watchFileEvents, 50*time.Millisecond, callbackFunc)
 
 	// sleep one second to make sure the watcher is set up before change is made
 	time.Sleep(time.Second)
@@ -106,7 +145,7 @@ func TestWatchCerts(t *testing.T) {
 	}
 
 	// should terminate immediately
-	go watchCerts(ctx, "", callbackFunc)
+	go watchCerts(ctx, nil, watchFileEvents, 50*time.Millisecond, callbackFunc)
 }
 
 func TestGenerateCertHash(t *testing.T) {
@@ -203,3 +242,5 @@ func TestEnvoyRun(t *testing.T) {
 		t.Errorf("expected error on bad config path")
 	}
 }
+
+var _ = flag.Lookup("v").Value.Set("99")


### PR DESCRIPTION
File watcher waits for maxDelay duration to deliver notification to updatefunc().

**What this PR does / why we need it**:
Current file watcher passes all events from fsnotify up to the agent. 
This can (and has) cause excessive event generation.

 It can also cause related events to be processed separately. For example cert and key file change events may be delivered separately even though they change together.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This is related to pr #1331 

**Special notes for your reviewer**:

```release-note
NONE
```
