### PR TITLE
remove nodeport from eureka service

### DIFF
--- a/test/integration/testdata/eureka.yaml.tmpl
+++ b/test/integration/testdata/eureka.yaml.tmpl
@@ -9,7 +9,6 @@ spec:
     - protocol: TCP
       port: 8080
       name: http
-  type: NodePort
 ---
 apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes `NodePort` designation from Eureka service. This might cause issues with the automated tests if it is not removed. Fortunately, no Eureka tests have been enabled yet, so it shouldn't be causing issues right now.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
