### PR TITLE
Switch to using a stable snapshot of gometalinter

### DIFF
--- a/adapter/config/ingress/status_test.go
+++ b/adapter/config/ingress/status_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-
 	v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/bin/check.sh
+++ b/bin/check.sh
@@ -5,7 +5,7 @@ buildifier -showlog -mode=check $(find . -type f \( -name 'BUILD' -or -name 'WOR
 
 NUM_CPU=$(getconf _NPROCESSORS_ONLN)
 
-gometalinter --concurrency=${NUM_CPU} --enable-gc --deadline=300s --disable-all\
+gometalinter.v1 --concurrency=${NUM_CPU} --enable-gc --deadline=300s --disable-all\
   --enable=aligncheck\
   --enable=deadcode\
   --enable=errcheck\

--- a/bin/check.sh
+++ b/bin/check.sh
@@ -20,7 +20,6 @@ gometalinter.v1 --concurrency=${NUM_CPU} --enable-gc --deadline=300s --disable-a
   --enable=ineffassign\
   --enable=interfacer\
   --enable=lll --line-length=120\
-  --enable=megacheck\
   --enable=misspell\
   --enable=structcheck\
   --enable=unconvert\
@@ -31,5 +30,6 @@ gometalinter.v1 --concurrency=${NUM_CPU} --enable-gc --deadline=300s --disable-a
 
 # Disabled linters:
 # --enable=dupl\
+# --enable=megacheck\
 # --enable=gocyclo\
 # --cyclo-over=15\

--- a/bin/install-prereqs.sh
+++ b/bin/install-prereqs.sh
@@ -3,8 +3,8 @@
 set -ex
 
 # Install linters
-go get -u github.com/alecthomas/gometalinter
-gometalinter --install --update --vendored-linters
+go get -u gopkg.in/alecthomas/gometalinter.v1
+gometalinter.v1 --install --update --vendored-linters
 
 # Install buildifier BUILD file validator
 go get -u github.com/bazelbuild/buildifier/buildifier

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -565,6 +565,7 @@ func readInputs() ([]model.Config, []crd.IstioKind, error) {
 }
 
 // Print a simple list of names
+// nolint: errcheck, gas
 func printShortOutput(_ *crd.Client, configList []model.Config) {
 	var w tabwriter.Writer
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
@@ -577,7 +578,7 @@ func printShortOutput(_ *crd.Client, configList []model.Config) {
 		)
 		fmt.Fprintf(&w, "%s\t%s\t%s\n", c.Name, kind, c.Namespace)
 	}
-	w.Flush() // nolint: errcheck
+	w.Flush()
 }
 
 // Print as YAML

--- a/platform/kube/admit/admit.go
+++ b/platform/kube/admit/admit.go
@@ -42,9 +42,9 @@ import (
 )
 
 const (
-	secretServerKey  = "server-key.pem"
-	secretServerCert = "server-cert.pem"
-	secretCACert     = "ca-cert.pem"
+	secretServerKey  = "server-key.pem"  // nolint: gas
+	secretServerCert = "server-cert.pem" // nolint: gas
+	secretCACert     = "ca-cert.pem"     // nolint: gas
 )
 
 // ControllerOptions contains the configuration for the Istio Pilot validation
@@ -244,7 +244,7 @@ func (ac *AdmissionController) Run(stop <-chan struct{}) {
 		}
 	}()
 	<-stop
-	server.Close() // nolint: errcheck
+	server.Close() // nolint: errcheck, gas
 }
 
 // Unregister unregisters the external admission webhook

--- a/proxy/net.go
+++ b/proxy/net.go
@@ -53,7 +53,10 @@ func WaitForPrivateNetwork() bool {
 
 // Returns a private IP address, or unspecified IP (0.0.0.0) if no IP is available
 func getPrivateIPIfAvailable() net.IP {
-	addrs, _ := net.InterfaceAddrs()
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return net.IPv4zero
+	}
 	for _, addr := range addrs {
 		var ip net.IP
 		switch v := addr.(type) {

--- a/test/eurekamirror/eurekamirror.go
+++ b/test/eurekamirror/eurekamirror.go
@@ -36,13 +36,14 @@ import (
 	"syscall"
 	"time"
 
-	"istio.io/pilot/model"
-	"istio.io/pilot/platform/kube"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+
+	"istio.io/pilot/model"
+	"istio.io/pilot/platform/kube"
 )
 
 var (

--- a/test/integration/egress.go
+++ b/test/integration/egress.go
@@ -20,9 +20,10 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"istio.io/pilot/platform"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/pilot/platform"
 )
 
 type egress struct {

--- a/test/integration/infra.go
+++ b/test/integration/infra.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	ingressSecretName = "istio-ingress-certs"
+	ingressSecretName = "istio-ingress-certs" //nolint: gas
 )
 
 type infra struct { // nolint: aligncheck

--- a/test/integration/ingress.go
+++ b/test/integration/ingress.go
@@ -19,8 +19,9 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"istio.io/pilot/platform"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/pilot/platform"
 )
 
 type ingress struct {

--- a/test/mock/config.go
+++ b/test/mock/config.go
@@ -191,7 +191,7 @@ func CheckMapInvariant(r model.ConfigStore, t *testing.T, namespace string, n in
 	}
 
 	// check for missing type
-	if l, _ := r.List("missing", namespace); len(l) > 0 {
+	if l, _ := r.List("missing", namespace); len(l) > 0 { // nolint: gas
 		t.Errorf("unexpected objects for missing type")
 	}
 
@@ -346,7 +346,7 @@ func CheckCacheFreshness(cache model.ConfigStoreCache, namespace string, t *test
 
 	// validate cache consistency
 	cache.RegisterEventHandler(model.MockConfig.Type, func(config model.Config, ev model.Event) {
-		elts, _ := cache.List(model.MockConfig.Type, namespace)
+		elts, _ := cache.List(model.MockConfig.Type, namespace) // nolint: gas
 		elt, exists := cache.Get(o.Type, o.Name, o.Namespace)
 		switch ev {
 		case model.EventAdd:
@@ -424,7 +424,7 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 	defer close(stop)
 	go cache.Run(stop)
 	util.Eventually(func() bool { return cache.HasSynced() }, t)
-	os, _ := cache.List(model.MockConfig.Type, namespace)
+	os, _ := cache.List(model.MockConfig.Type, namespace) // nolint: gas
 	if len(os) != n {
 		t.Errorf("cache.List => Got %d, expected %d", len(os), n)
 	}
@@ -438,7 +438,7 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 
 	// check again in the controller cache
 	util.Eventually(func() bool {
-		os, _ = cache.List(model.MockConfig.Type, namespace)
+		os, _ = cache.List(model.MockConfig.Type, namespace) // nolint: gas
 		glog.Infof("cache.List => Got %d, expected %d", len(os), 0)
 		return len(os) == 0
 	}, t)
@@ -452,8 +452,8 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 
 	// check directly through the client
 	util.Eventually(func() bool {
-		cs, _ := cache.List(model.MockConfig.Type, namespace)
-		os, _ := store.List(model.MockConfig.Type, namespace)
+		cs, _ := cache.List(model.MockConfig.Type, namespace) // nolint: gas
+		os, _ := store.List(model.MockConfig.Type, namespace) // nolint: gas
 		glog.Infof("cache.List => Got %d, expected %d", len(cs), n)
 		glog.Infof("store.List => Got %d, expected %d", len(os), n)
 		return len(os) == n && len(cs) == n

--- a/test/server/echo.go
+++ b/test/server/echo.go
@@ -82,6 +82,7 @@ type codeAndSlices struct {
 	slices           int
 }
 
+// nolint: errcheck, gas
 func (h handler) addResponsePayload(r *http.Request, body *bytes.Buffer) {
 
 	body.WriteString("ServiceVersion=" + version + "\n")


### PR DESCRIPTION
**What this PR does / why we need it**: Pilot presubmits have been failing due to linter issues introduced by changing linter versions. This PR pins pilot to using gometalinter.v1.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I also "fix" any new linter issues that popped up. Unfortunately gas doesn't recognize `_, _ = foo()` as "handling" an error, even if we explicitly ignore the error, so I had to annotate quite a few places as nolint. In config.go I actually attempted to handle the errors the linter was complaining about, but that resulted in test failures so I left them as-is.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
