### PR TITLE
skip empty objects for the input files of istioctl commands

### DIFF
--- a/adapter/config/crd/conversion.go
+++ b/adapter/config/crd/conversion.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 
 	"github.com/golang/glog"
@@ -112,6 +113,7 @@ func ParseInputs(inputs string) ([]model.Config, []IstioKind, error) {
 	var varr []model.Config
 	var others []IstioKind
 	reader := bytes.NewReader([]byte(inputs))
+	var empty = IstioKind{}
 
 	// We store configs as a YaML stream; there may be more than one decoder.
 	yamlDecoder := kubeyaml.NewYAMLOrJSONDecoder(reader, 512*1024)
@@ -123,6 +125,9 @@ func ParseInputs(inputs string) ([]model.Config, []IstioKind, error) {
 		}
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot parse proto message: %v", err)
+		}
+		if reflect.DeepEqual(obj, empty) {
+			continue
 		}
 
 		schema, exists := model.IstioConfigTypes.GetByType(CamelCaseToKabobCase(obj.Kind))

--- a/adapter/config/crd/conversion_test.go
+++ b/adapter/config/crd/conversion_test.go
@@ -78,13 +78,16 @@ func TestConvert(t *testing.T) {
 
 func TestParseInputs(t *testing.T) {
 	if varr, _, err := ParseInputs(""); len(varr) > 0 || err != nil {
-		t.Errorf("ParseInput(\"\") => got %v, %v, want nil, nil", varr, err)
+		t.Errorf(`ParseInput("") => got %v, %v, want nil, nil`, varr, err)
 	}
 	if _, _, err := ParseInputs("a"); err == nil {
-		t.Error("ParseInput(\"a\") => got no error")
+		t.Error(`ParseInput("a") => got no error`)
 	}
 	if _, others, err := ParseInputs("kind: Pod"); err != nil || len(others) != 1 {
-		t.Errorf("ParseInput(\"kind: Pod\") => got %v, %v", others, err)
+		t.Errorf(`ParseInput("kind: Pod") => got %v, %v`, others, err)
+	}
+	if varr, others, err := ParseInputs("---\n"); err != nil || len(varr) != 0 || len(others) != 0 {
+		t.Errorf(`ParseInput("---") => got %v, %v, %v`, varr, others, err)
 	}
 	if _, _, err := ParseInputs("kind: RouteRule\nspec:\n  destination: x"); err == nil {
 		t.Error("ParseInput(bad spec) => got no error")


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes empty content can be in the input file(s) for istioctl and such empty config data can result in
errors, since istioctl doesn't know how to handle such data. They should be skipped.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1351

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
