### PR TITLE
WIP: Setting the Envoy tracing operation name for inbound and outboun…

### DIFF
--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -228,7 +228,7 @@ func buildSidecarListenersClusters(
 			httpOutbound.clusters()...)
 		listeners = append(listeners,
 			buildHTTPListener(mesh, node, instances, nil, LocalhostAddress, int(mesh.ProxyHttpPort),
-					RDSAll, false, EgressTraceOperation))
+				RDSAll, false, EgressTraceOperation))
 		// TODO: need inbound listeners in HTTP_PROXY case, with dedicated ingress listener.
 	}
 

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -227,7 +227,8 @@ func buildSidecarListenersClusters(
 		clusters = append(clusters,
 			httpOutbound.clusters()...)
 		listeners = append(listeners,
-			buildHTTPListener(mesh, node, instances, nil, LocalhostAddress, int(mesh.ProxyHttpPort), RDSAll, false, EgressTraceOperation))
+			buildHTTPListener(mesh, node, instances, nil, LocalhostAddress, int(mesh.ProxyHttpPort),
+					RDSAll, false, EgressTraceOperation))
 		// TODO: need inbound listeners in HTTP_PROXY case, with dedicated ingress listener.
 	}
 
@@ -409,7 +410,8 @@ func buildOutboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node, in
 
 	for port, routeConfig := range httpOutbound {
 		listeners = append(listeners,
-			buildHTTPListener(mesh, sidecar, instances, routeConfig, WildcardAddress, port, fmt.Sprintf("%d", port), false, EgressTraceOperation))
+			buildHTTPListener(mesh, sidecar, instances, routeConfig, WildcardAddress, port,
+				fmt.Sprintf("%d", port), false, EgressTraceOperation))
 		clusters = append(clusters, routeConfig.clusters()...)
 	}
 
@@ -661,7 +663,8 @@ func buildInboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node,
 
 			config := &HTTPRouteConfig{VirtualHosts: []*VirtualHost{host}}
 			listeners = append(listeners,
-				buildHTTPListener(mesh, sidecar, instances, config, endpoint.Address, endpoint.Port, "", false, IngressTraceOperation))
+				buildHTTPListener(mesh, sidecar, instances, config, endpoint.Address,
+					endpoint.Port, "", false, IngressTraceOperation))
 
 		case model.ProtocolTCP, model.ProtocolHTTPS, model.ProtocolMONGO:
 			listener := buildTCPListener(&TCPRouteConfig{

--- a/proxy/envoy/egress.go
+++ b/proxy/envoy/egress.go
@@ -28,7 +28,7 @@ import (
 func buildEgressListeners(mesh *proxyconfig.MeshConfig, egress proxy.Node) Listeners {
 	port := proxy.ParsePort(mesh.EgressProxyAddress)
 	listener := buildHTTPListener(mesh, egress, nil, nil, WildcardAddress, port, fmt.Sprintf("%d", port),
-			false, IngressTraceOperation)
+		false, IngressTraceOperation)
 	applyInboundAuth(listener, mesh)
 	return Listeners{listener}
 }

--- a/proxy/envoy/egress.go
+++ b/proxy/envoy/egress.go
@@ -27,7 +27,8 @@ import (
 
 func buildEgressListeners(mesh *proxyconfig.MeshConfig, egress proxy.Node) Listeners {
 	port := proxy.ParsePort(mesh.EgressProxyAddress)
-	listener := buildHTTPListener(mesh, egress, nil, nil, WildcardAddress, port, fmt.Sprintf("%d", port), false, IngressTraceOperation)
+	listener := buildHTTPListener(mesh, egress, nil, nil, WildcardAddress, port, fmt.Sprintf("%d", port),
+			false, IngressTraceOperation)
 	applyInboundAuth(listener, mesh)
 	return Listeners{listener}
 }

--- a/proxy/envoy/egress.go
+++ b/proxy/envoy/egress.go
@@ -27,7 +27,7 @@ import (
 
 func buildEgressListeners(mesh *proxyconfig.MeshConfig, egress proxy.Node) Listeners {
 	port := proxy.ParsePort(mesh.EgressProxyAddress)
-	listener := buildHTTPListener(mesh, egress, nil, nil, WildcardAddress, port, fmt.Sprintf("%d", port), false)
+	listener := buildHTTPListener(mesh, egress, nil, nil, WildcardAddress, port, fmt.Sprintf("%d", port), false, IngressTraceOperation)
 	applyInboundAuth(listener, mesh)
 	return Listeners{listener}
 }

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -32,14 +32,14 @@ func buildIngressListeners(mesh *proxyconfig.MeshConfig,
 	config model.IstioConfigStore,
 	ingress proxy.Node) Listeners {
 	listeners := Listeners{
-		buildHTTPListener(mesh, ingress, nil, nil, WildcardAddress, 80, "80", true),
+		buildHTTPListener(mesh, ingress, nil, nil, WildcardAddress, 80, "80", true, EgressTraceOperation),
 	}
 
 	// lack of SNI in Envoy implies that TLS secrets are attached to listeners
 	// therefore, we should first check that TLS endpoint is needed before shipping TLS listener
 	_, secret := buildIngressRoutes(mesh, discovery, config)
 	if secret != "" {
-		listener := buildHTTPListener(mesh, ingress, nil, nil, WildcardAddress, 443, "443", true)
+		listener := buildHTTPListener(mesh, ingress, nil, nil, WildcardAddress, 443, "443", true, EgressTraceOperation)
 		listener.SSLContext = &SSLContext{
 			CertChainFile:  path.Join(proxy.IngressCertsPath, proxy.IngressCertFilename),
 			PrivateKeyFile: path.Join(proxy.IngressCertsPath, proxy.IngressKeyFilename),

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -90,6 +90,9 @@ const (
 	// LocalhostAddress for local binding
 	LocalhostAddress = "127.0.0.1"
 
+	// EgressTraceOperation denotes the name of trace operation for Envoy
+	EgressTraceOperation = "egress"
+
 	// IngressTraceOperation denotes the name of trace operation for Envoy
 	IngressTraceOperation = "ingress"
 

--- a/proxy/envoy/testdata/lds-httpproxy.json.golden
+++ b/proxy/envoy/testdata/lds-httpproxy.json.golden
@@ -12,7 +12,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-ingress.json.golden
+++ b/proxy/envoy/testdata/lds-ingress.json.golden
@@ -13,7 +13,7 @@
        "generate_request_id": true,
        "use_remote_address": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -65,7 +65,7 @@
        "generate_request_id": true,
        "use_remote_address": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-egress-rule-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-egress-rule-auth.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -175,7 +175,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-egress-rule-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-egress-rule-nomixer.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -55,7 +55,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -91,7 +91,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -127,7 +127,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-egress-rule.json.golden
+++ b/proxy/envoy/testdata/lds-v0-egress-rule.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -175,7 +175,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -155,7 +155,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-fault-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault-nomixer.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -55,7 +55,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-fault.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -155,7 +155,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-none-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none-auth.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-none-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none-nomixer.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -55,7 +55,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -91,7 +91,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-none.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-weighted-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted-nomixer.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -55,7 +55,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -91,7 +91,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v0-weighted.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-egress-rule-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-egress-rule-auth.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -175,7 +175,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-egress-rule-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-egress-rule-nomixer.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -55,7 +55,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -91,7 +91,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -127,7 +127,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-egress-rule.json.golden
+++ b/proxy/envoy/testdata/lds-v1-egress-rule.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -175,7 +175,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-fault-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault-nomixer.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -55,7 +55,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -91,7 +91,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-fault.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-none-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none-auth.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-none-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none-nomixer.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -55,7 +55,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -91,7 +91,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-none.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-weighted-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted-nomixer.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -55,7 +55,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -91,7 +91,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-v1-weighted.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",

--- a/proxy/envoy/testdata/lds-websocket.json.golden
+++ b/proxy/envoy/testdata/lds-websocket.json.golden
@@ -19,7 +19,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -71,7 +71,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",
@@ -123,7 +123,7 @@
        "stat_prefix": "http",
        "generate_request_id": true,
        "tracing": {
-        "operation_name": "ingress"
+        "operation_name": "egress"
        },
        "rds": {
         "cluster": "rds",


### PR DESCRIPTION
…d listeners

**What this PR does / why we need it**:
Currently the envoy configuration only sets the Tracing/OperationName to Ingress. A recent change to the Envoy proxy now derives the tracing span kind (client/server) from this OperationName, and therefore at the moment all spans are being created as server spans. This is resulting in invalid zipkin traces.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes istio/issues#72

**Special notes for your reviewer**:
I've ran the unit tests, which passed - but I'm getting linker errors when trying to run the e2e tests - will continue to investigate, but thought I would create the PR in the meantime to get the CI tests running. Therefore I haven't been able to test it against a real scenario (e.g. bookinfo) to confirm that it provides an actual fix.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
