### PR TITLE
fix: remove hyphens from istioctl types help text 

### DIFF
--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -68,7 +68,7 @@ var (
 		Short:             "Istio control interface",
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,
-		Long: fmt.Sprintf(`
+		Long: `
 Istio configuration command line utility.
 
 Create, list, modify, and delete configuration resources in the Istio
@@ -76,12 +76,12 @@ system.
 
 Available routing and traffic management configuration types:
 
-	%v
+	[routerule ingressrule egressrule destinationpolicy]
 
 See http://istio.io/docs/reference for an overview of routing rules
 and destination policies.
 
-`, model.IstioConfigTypes.Types()),
+`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			defaultNamespace = getDefaultNamespace(kubeconfig)
 		},


### PR DESCRIPTION
Updated example test on `istioctl`.

**What this PR does / why we need it**:
Fixes this `istioctl` command output:

```
$ istioctl 

Istio configuration command line utility.

Create, list, modify, and delete configuration resources in the Istio
system.

Available routing and traffic management configuration types:

        [route-rule ingress-rule egress-rule destination-policy]

```

The routing and traffic management types should now be hyphen-less as per rest of CLI. 

**Which issue this PR fixes** 
None 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
