### PR TITLE
tracing: Provide a more meaningful service name in traces

### DIFF
--- a/platform/kube/inject/testdata/auth.cert-dir.yaml.injected
+++ b/platform/kube/inject/testdata/auth.cert-dir.yaml.injected
@@ -35,7 +35,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/platform/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -35,7 +35,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/auth.yaml.injected
+++ b/platform/kube/inject/testdata/auth.yaml.injected
@@ -35,7 +35,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/daemonset.yaml.injected
+++ b/platform/kube/inject/testdata/daemonset.yaml.injected
@@ -33,7 +33,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/platform/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -35,7 +35,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/frontend.yaml.injected
+++ b/platform/kube/inject/testdata/frontend.yaml.injected
@@ -53,7 +53,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/hello-always.yaml.injected
+++ b/platform/kube/inject/testdata/hello-always.yaml.injected
@@ -35,7 +35,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/platform/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -35,7 +35,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/hello-multi.yaml.injected
+++ b/platform/kube/inject/testdata/hello-multi.yaml.injected
@@ -36,7 +36,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration
@@ -144,7 +144,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/hello-never.yaml.injected
+++ b/platform/kube/inject/testdata/hello-never.yaml.injected
@@ -35,7 +35,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/hello-probes.yaml.injected
+++ b/platform/kube/inject/testdata/hello-probes.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/hello.yaml.injected
+++ b/platform/kube/inject/testdata/hello.yaml.injected
@@ -35,7 +35,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/multi-init.yaml.injected
+++ b/platform/kube/inject/testdata/multi-init.yaml.injected
@@ -35,7 +35,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/replicaset.yaml.injected
+++ b/platform/kube/inject/testdata/replicaset.yaml.injected
@@ -32,7 +32,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/replicationcontroller.yaml.injected
+++ b/platform/kube/inject/testdata/replicationcontroller.yaml.injected
@@ -34,7 +34,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - nginx
         - --drainDuration
         - 2s
         - --parentShutdownDuration

--- a/platform/kube/inject/testdata/statefulset.yaml.injected
+++ b/platform/kube/inject/testdata/statefulset.yaml.injected
@@ -38,7 +38,7 @@ spec:
         - --binaryPath
         - /usr/local/bin/envoy
         - --serviceCluster
-        - istio-proxy
+        - hello
         - --drainDuration
         - 2s
         - --parentShutdownDuration


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently all trace spans generated by Istio proxied services are associated with the name 'istio-proxy'. This is confusing for end users, with the only indication of what services are being called, being the operation name which provides the hostname being called.

This PR enables the Deployment template's 'app' label value (if present) to be used as the service name.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: This PR outlines the issue as well as providing a potential fix.

**Special notes for your reviewer**:
The [istio service cluster configuration](https://github.com/istio/api/blob/master/proxy/v1/config/proxy_mesh.proto#L30-L42) comment seems to suggest that the reason a common 'istio-proxy' value is used, as Istio doesn't require a meaningful value to be able to do source caller routing. However this `service-cluster` value is also used by the tracing information produced by Envoy, to represent the service name.

The 'app' label has been selected, as it seems an appropriate single name that could be used by the proxy for a service name related to requests inbound/outbound of the potentially multiple containers within the deployment - but if a more appropriate source for a service name is available, then can be discussed.

A trace of the bookinfo example now looks like:

![istio-jaeger](https://user-images.githubusercontent.com/164562/30971798-e6ab35fe-a460-11e7-9f9d-253a2c1e72bb.png)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
If the Deployment object within the kubernetes template includes an 'app' label, this value will be used as the service name associated with any tracing information generated via the proxy.
```
