### PR TITLE
add locking to pod cache

### DIFF
--- a/platform/kube/cache.go
+++ b/platform/kube/cache.go
@@ -75,9 +75,6 @@ func (pc *PodCache) getPodByIP(addr string) (*v1.Pod, bool) {
 
 // labelsByIP returns pod labels or nil if pod not found or an error occurred
 func (pc *PodCache) labelsByIP(addr string) (model.Labels, bool) {
-	pc.rwMu.RLock()
-	defer pc.rwMu.RUnlock()
-
 	pod, exists := pc.getPodByIP(addr)
 	if !exists {
 		return nil, false

--- a/platform/kube/cache.go
+++ b/platform/kube/cache.go
@@ -15,6 +15,8 @@
 package kube
 
 import (
+	"sync"
+
 	"k8s.io/api/core/v1"
 
 	"istio.io/pilot/model"
@@ -22,6 +24,7 @@ import (
 
 // PodCache is an eventually consistent pod cache
 type PodCache struct {
+	rwMu sync.RWMutex
 	cacheHandler
 
 	// keys maintains stable pod IP to name key mapping
@@ -36,6 +39,9 @@ func newPodCache(ch cacheHandler) *PodCache {
 	}
 
 	ch.handler.Append(func(obj interface{}, ev model.Event) error {
+		out.rwMu.Lock()
+		defer out.rwMu.Unlock()
+
 		pod := *obj.(*v1.Pod)
 		ip := pod.Status.PodIP
 		if len(ip) > 0 {
@@ -53,6 +59,9 @@ func newPodCache(ch cacheHandler) *PodCache {
 
 // getPodByIp returns the pod or nil if pod not found or an error occurred
 func (pc *PodCache) getPodByIP(addr string) (*v1.Pod, bool) {
+	pc.rwMu.RLock()
+	defer pc.rwMu.RUnlock()
+
 	key, exists := pc.keys[addr]
 	if !exists {
 		return nil, false
@@ -66,6 +75,9 @@ func (pc *PodCache) getPodByIP(addr string) (*v1.Pod, bool) {
 
 // labelsByIP returns pod labels or nil if pod not found or an error occurred
 func (pc *PodCache) labelsByIP(addr string) (model.Labels, bool) {
+	pc.rwMu.RLock()
+	defer pc.rwMu.RUnlock()
+
 	pod, exists := pc.getPodByIP(addr)
 	if !exists {
 		return nil, false


### PR DESCRIPTION
**What this PR does / why we need it**:
PodCache has no mutex protecting its internal state. Add RWMutex to fix this.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1377 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix race in Pilot PodCache
```
