### PR TITLE
update for bazel 0.6.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,13 +2,14 @@ workspace(name = "com_github_istio_pilot")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "eba68677493422112dd25f6a0b4bbdb02387e5a4",  # Aug 1, 2017
+    commit = "0e5a0e51b4e9fc3b5ef1436639a43fce27559744",  # Oct 3, 2017
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "go_repository")
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_repository", "go_register_toolchains")
 
-go_repositories()
+go_rules_dependencies()
+go_register_toolchains()
 
 ##
 ## Kubernetes dependencies

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,12 @@ git_repository(
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 
+git_repository(
+    name = "com_github_google_protobuf",
+    commit = "593e917c176b5bc5aafa57bf9f6030d749d91cd5",  # Jan 2017 3.2.0
+    remote = "https://github.com/google/protobuf.git",
+)
+
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_repository", "go_register_toolchains")
 
 go_rules_dependencies()
@@ -447,12 +453,6 @@ go_repository(
     name = "com_github_golang_protobuf",
     commit = "8ee79997227bf9b34611aee7946ae64735e6fd93",
     importpath = "github.com/golang/protobuf",
-)
-
-git_repository(
-    name = "com_github_google_protobuf",
-    commit = "593e917c176b5bc5aafa57bf9f6030d749d91cd5",  # Jan 2017 3.2.0
-    remote = "https://github.com/google/protobuf.git",
 )
 
 go_repository(


### PR DESCRIPTION
**What this PR does / why we need it**: addresses a couple of issues that fail the build when updating bazel to 0.6.0

**Which issue this PR fixes*:
fixes:
```shell
[vbatts@getdown] (master) ~/src/istio.io/pilot$ bazel build //...
ERROR: /home/vbatts/.cache/bazel/_bazel_vbatts/4cef8fba7ce23e923fa298b99fb665e8/external/io_bazel_rules_go/go/private/binary.bzl:226:48: name 'lib' is not defined (did you mean 'libs'?).
ERROR: error loading package '': Extension 'go/private/binary.bzl' has errors.
INFO: Elapsed time: 1.107s
```
and
```shell
[vbatts@getdown] {master *} ~/src/istio.io/pilot$ bazel build //...
ERROR: /home/vbatts/src/github.com/istio/pilot/WORKSPACE:452:1: Cannot redefine repository after any load statement in the WORKSPACE file (for repository 'com_github_google_protobuf').
ERROR: Error evaluating WORKSPACE file.
ERROR: error loading package 'external': Package 'external' contains errors.
INFO: Elapsed time: 0.063s
```

**Special notes for your reviewer**:
With the update to bazel 0.6.0, there were pilot build failures due to syntax in the commit of rules_go used. This updates to latest master.
Also, no git_repository can be done after load().

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
