### PR TITLE
WIP: Add support for Decorator, which enables the operation/span name…

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -461,7 +461,7 @@ go_repository(
 )
 
 # This SHA is obtained from istio/api
-ISTIO_API = "3520b5436dd8d8bc7c27fc1f9f267093f7254cf6"
+ISTIO_API = "995768771a45f1bd63a5750590cdf7734482c184"
 
 new_git_repository(
     name = "io_istio_api",
@@ -489,7 +489,7 @@ filegroup(
 )
     """,
     commit = ISTIO_API,
-    remote = "https://github.com/istio/api.git",
+    remote = "https://github.com/objectiser/istio-api.git",
 )
 
 GOOGLEAPIS_BUILD_FILE = """

--- a/adapter/config/crd/conversion_test.go
+++ b/adapter/config/crd/conversion_test.go
@@ -100,4 +100,9 @@ func TestParseInputs(t *testing.T) {
 	if err != nil || len(varr) == 0 {
 		t.Errorf("ParseInputs(correct input) => got %v, %v", varr, err)
 	}
+
+	varr, _, err = ParseInputs("kind: RouteRule\nspec:\n  destination:\n    service: x\n  decorator:\n    operation: hello")
+	if err != nil || len(varr) == 0 {
+		t.Errorf("ParseInputs(correct input) => got %v, %v", varr, err)
+	}
 }

--- a/model/conversion_test.go
+++ b/model/conversion_test.go
@@ -37,6 +37,9 @@ func TestProtoSchemaConversions(t *testing.T) {
 			{Destination: &proxyconfig.IstioService{Name: "bar"}, Weight: 75},
 			{Destination: &proxyconfig.IstioService{Name: "baz"}, Weight: 25},
 		},
+		Decorator: &proxyconfig.Decorator{
+			Operation: "foobar",
+		},
 	}
 
 	wantJSON := `
@@ -58,11 +61,16 @@ func TestProtoSchemaConversions(t *testing.T) {
 			},
 			"weight": 25
 		}
-		]
+		],
+		"decorator": {
+			"operation": "foobar"
+		}
 	}
 	`
 
-	wantYAML := "destination:\n" +
+	wantYAML := "decorator:\n" +
+		"  operation: foobar\n" +
+		"destination:\n" +
 		"  name: foo\n" +
 		"precedence: 5\n" +
 		"route:\n" +
@@ -91,6 +99,9 @@ func TestProtoSchemaConversions(t *testing.T) {
 				},
 				"weight": 25.0,
 			},
+		},
+		"decorator": map[string]interface{}{
+			"operation": "foobar",
 		},
 	}
 

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -216,6 +216,11 @@ type Runtime struct {
 	Default int    `json:"default"`
 }
 
+// Decorator definition
+type Decorator struct {
+	Operation     string `json:"operation"`
+}
+
 // HTTPRoute definition
 type HTTPRoute struct {
 	Runtime *Runtime `json:"runtime,omitempty"`
@@ -239,6 +244,8 @@ type HTTPRoute struct {
 
 	AutoHostRewrite  bool `json:"auto_host_rewrite,omitempty"`
 	WebsocketUpgrade bool `json:"use_websocket,omitempty"`
+
+	Decorator    *Decorator		`json:"decorator,omitempty"`
 
 	// clusters contains the set of referenced clusters in the route; the field is special
 	// and used only to aggregate cluster information after composing routes

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -199,6 +199,10 @@ func buildHTTPRoute(config model.Config, service *model.Service, port *model.Por
 		route.WebsocketUpgrade = true
 	}
 
+	if rule.Decorator != nil {
+		route.Decorator = buildDecorator(rule.Decorator)
+	}
+
 	return route
 }
 
@@ -213,6 +217,12 @@ func buildCluster(address, name string, timeout *duration.Duration) *Cluster {
 				URL: "tcp://" + address,
 			},
 		},
+	}
+}
+
+func buildDecorator(decorator *proxyconfig.Decorator) *Decorator {
+	return &Decorator{
+		Operation:             decorator.Operation,
 	}
 }
 

--- a/test/integration/routing.go
+++ b/test/integration/routing.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -50,28 +51,28 @@ func (t *routing) run() error {
 			description: "routing all traffic to c-v1",
 			config:      "rule-default-route.yaml.tmpl",
 			check: func() error {
-				return t.verifyRouting("http", "a", "c", "", "", 100, map[string]int{"v1": 100, "v2": 0})
+				return t.verifyRouting("http", "a", "c", "", "", 100, map[string]int{"v1": 100, "v2": 0}, "hello")
 			},
 		},
 		{
 			description: "routing 75 percent to c-v1, 25 percent to c-v2",
 			config:      "rule-weighted-route.yaml.tmpl",
 			check: func() error {
-				return t.verifyRouting("http", "a", "c", "", "", 100, map[string]int{"v1": 75, "v2": 25})
+				return t.verifyRouting("http", "a", "c", "", "", 100, map[string]int{"v1": 75, "v2": 25}, "")
 			},
 		},
 		{
 			description: "routing 100 percent to c-v2 using header",
 			config:      "rule-content-route.yaml.tmpl",
 			check: func() error {
-				return t.verifyRouting("http", "a", "c", "version", "v2", 100, map[string]int{"v1": 0, "v2": 100})
+				return t.verifyRouting("http", "a", "c", "version", "v2", 100, map[string]int{"v1": 0, "v2": 100}, "")
 			},
 		},
 		{
 			description: "routing 100 percent to c-v2 using regex header",
 			config:      "rule-regex-route.yaml.tmpl",
 			check: func() error {
-				return t.verifyRouting("http", "a", "c", "foo", "bar", 100, map[string]int{"v1": 0, "v2": 100})
+				return t.verifyRouting("http", "a", "c", "foo", "bar", 100, map[string]int{"v1": 0, "v2": 100}, "")
 			},
 		},
 		{
@@ -98,7 +99,7 @@ func (t *routing) run() error {
 			description: "routing 100 percent to c-v1 with websocket upgrades",
 			config:      "rule-websocket-route.yaml.tmpl",
 			check: func() error {
-				return t.verifyRouting("ws", "a", "c", "testwebsocket", "enabled", 100, map[string]int{"v1": 100, "v2": 0})
+				return t.verifyRouting("ws", "a", "c", "testwebsocket", "enabled", 100, map[string]int{"v1": 100, "v2": 0}, "")
 			},
 		},
 	}
@@ -137,7 +138,7 @@ func counts(elts []string) map[string]int {
 
 // verifyRouting verifies if the traffic is split as specified across different deployments in a service
 func (t *routing) verifyRouting(scheme, src, dst, headerKey, headerVal string,
-	samples int, expectedCount map[string]int) error {
+	samples int, expectedCount map[string]int, operation string) error {
 	url := fmt.Sprintf("%s://%s/%s", scheme, dst, src)
 	glog.Infof("Making %d requests (%s) from %s...\n", samples, url, src)
 
@@ -154,7 +155,32 @@ func (t *routing) verifyRouting(scheme, src, dst, headerKey, headerVal string,
 		}
 	}
 
+	if operation != "" {
+		errs = t.verifyDecorator(operation)
+	}
+
 	return errs
+}
+
+// verify that the traces were picked up by Zipkin and decorator has been applied
+func (t *routing) verifyDecorator(operation string) error {
+	response := t.infra.clientRequest(
+		"t",
+		fmt.Sprintf("http://zipkin.%s:9411/api/v1/traces",
+			t.IstioNamespace),
+		1, "",
+	)
+
+	if len(response.code) == 0 || response.code[0] != httpOk {
+		return errAgain
+	}
+
+	text := fmt.Sprintf("\"name\":\"%s\"", operation)
+	if !strings.Contains(response.body, text) {
+		return errAgain
+	}
+
+	return nil
 }
 
 // verifyFaultInjection verifies if the fault filter was setup properly

--- a/test/integration/testdata/rule-default-route.yaml.tmpl
+++ b/test/integration/testdata/rule-default-route.yaml.tmpl
@@ -10,3 +10,5 @@ spec:
     - labels:
          version: v1
       weight: 100
+  decorator:
+    operation: hello

--- a/test/integration/zipkin.go
+++ b/test/integration/zipkin.go
@@ -85,8 +85,8 @@ func (t *zipkin) verifyTraces() error {
 		for _, id := range t.traces {
 			response := t.infra.clientRequest(
 				"t",
-				fmt.Sprintf("http://zipkin.%s:9411/api/v1/traces?annotationQuery=guid:x-request-id=/%s",
-					t.IstioNamespace, id),
+				fmt.Sprintf("http://zipkin.%s:9411/api/v1/traces",
+					t.IstioNamespace),
 				1, "",
 			)
 


### PR DESCRIPTION
… to be specified

**What this PR does / why we need it**:
This PR enables a user to specify an operation name associated with the route, that can be used in the tracing operation/span name.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This PR is currently using my fork of the istio/api repo, until https://github.com/istio/api/pull/186 is merged.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
This enhancement will enable a specific tracing span/operation name to be associated with a route. This can be used to provide business relevant (meaningful) names for specific REST endpoints.
```
