### PR TITLE
Ingress bug fixes

### DIFF
--- a/adapter/config/ingress/conversion.go
+++ b/adapter/config/ingress/conversion.go
@@ -107,6 +107,10 @@ func createIngressRule(name, host, path, domainSuffix string,
 				MatchType: &proxyconfig.StringMatch_Exact{Exact: path},
 			}
 		}
+	} else {
+		rule.Match.Request.Headers[model.HeaderURI] = &proxyconfig.StringMatch{
+			MatchType: &proxyconfig.StringMatch_Prefix{Prefix: "/"},
+		}
 	}
 
 	return model.Config{

--- a/cmd/pilot-agent/main.go
+++ b/cmd/pilot-agent/main.go
@@ -51,7 +51,6 @@ var (
 	connectTimeout         time.Duration
 	statsdUdpAddress       string // nolint: golint
 	proxyAdminPort         int
-	ingressOverride        bool
 
 	rootCmd = &cobra.Command{
 		Use:   "agent",
@@ -143,11 +142,6 @@ var (
 			}
 
 			if role.Type == proxy.Ingress {
-				// Run this as ingress controller only to gain access to the LB ports
-				// all other ingress configurations will be provided by standard route rules
-				if ingressOverride {
-					role.Type = proxy.Sidecar
-				}
 				certs = append(certs, envoy.CertSource{
 					Directory: proxy.IngressCertsPath,
 					Files:     []string{proxy.IngressCertFilename, proxy.IngressKeyFilename},
@@ -221,8 +215,6 @@ func init() {
 		"IP Address and Port of a statsd UDP listener (e.g. 10.75.241.127:9125)")
 	proxyCmd.PersistentFlags().IntVar(&proxyAdminPort, "proxyAdminPort", int(values.ProxyAdminPort),
 		"Port on which Envoy should listen for administrative commands")
-	proxyCmd.PersistentFlags().BoolVar(&ingressOverride, "ingressOverride", false,
-		"Ignore Kubernetes Ingress resource and use only Istio route rules for ingress")
 
 	cmd.AddFlags(rootCmd)
 

--- a/proxy/envoy/testdata/rds-ingress-weighted.json.golden
+++ b/proxy/envoy/testdata/rds-ingress-weighted.json.golden
@@ -3,7 +3,8 @@
    {
     "name": "world.com",
     "domains": [
-     "world.com"
+     "world.com",
+     "world.com:80"
     ],
     "routes": [
      {

--- a/proxy/envoy/testdata/rds-ingress.json.golden
+++ b/proxy/envoy/testdata/rds-ingress.json.golden
@@ -3,7 +3,8 @@
    {
     "name": "world.com",
     "domains": [
-     "world.com"
+     "world.com",
+     "world.com:80"
     ],
     "routes": [
      {


### PR DESCRIPTION
**What this PR does / why we need it**:
Some drive by bug fixes (attach port to the vhost so that requests with port can also be matched), use ingress instances when filtering routes, so that route rules can be scoped to ingress only.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/istio/issues/issues/87
https://github.com/istio/issues/issues/60


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ingress will allow port numbers in the authority header
```
