### PR TITLE
Use the route name to define the tracing span/operation name.

### DIFF
--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -705,13 +705,7 @@ func buildInboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node,
 				model.SortRouteRules(rules)
 				for _, config := range rules {
 					rule := config.Spec.(*proxyconfig.RouteRule)
-					var route *HTTPRoute
-					if rule.WebsocketUpgrade {
-						route = buildInboundWebsocketRoute(rule, cluster)
-					} else if config.ConfigMeta.Name != "" {
-						route = buildInboundRoute(config, rule, cluster)
-					}
-					if route != nil {
+					if route := buildInboundRoute(config, rule, cluster); route != nil {
 						// set server-side mixer filter config for inbound HTTP routes
 						// Note: websocket routes do not call the filter chain. Will be
 						// resolved in future.

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -224,6 +224,11 @@ type Runtime struct {
 	Default int    `json:"default"`
 }
 
+// Decorator definition
+type Decorator struct {
+	Operation     string `json:"operation"`
+}
+
 // HTTPRoute definition
 type HTTPRoute struct {
 	Runtime *Runtime `json:"runtime,omitempty"`
@@ -247,6 +252,8 @@ type HTTPRoute struct {
 
 	AutoHostRewrite  bool `json:"auto_host_rewrite,omitempty"`
 	WebsocketUpgrade bool `json:"use_websocket,omitempty"`
+
+	Decorator    *Decorator		`json:"decorator,omitempty"`
 
 	// clusters contains the set of referenced clusters in the route; the field is special
 	// and used only to aggregate cluster information after composing routes

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -226,7 +226,7 @@ type Runtime struct {
 
 // Decorator definition
 type Decorator struct {
-	Operation     string `json:"operation"`
+	Operation string `json:"operation"`
 }
 
 // HTTPRoute definition
@@ -253,7 +253,7 @@ type HTTPRoute struct {
 	AutoHostRewrite  bool `json:"auto_host_rewrite,omitempty"`
 	WebsocketUpgrade bool `json:"use_websocket,omitempty"`
 
-	Decorator    *Decorator		`json:"decorator,omitempty"`
+	Decorator *Decorator `json:"decorator,omitempty"`
 
 	// clusters contains the set of referenced clusters in the route; the field is special
 	// and used only to aggregate cluster information after composing routes

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -65,6 +65,9 @@ func buildDefaultRoute(cluster *Cluster) *HTTPRoute {
 		Prefix:   "/",
 		Cluster:  cluster.Name,
 		clusters: []*Cluster{cluster},
+		Decorator: &Decorator{
+			Operation: "default-route",
+		},
 	}
 }
 

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -68,25 +68,11 @@ func buildDefaultRoute(cluster *Cluster) *HTTPRoute {
 	}
 }
 
-func buildInboundWebsocketRoute(rule *proxyconfig.RouteRule, cluster *Cluster) *HTTPRoute {
-	route := buildHTTPRouteMatch(rule.Match)
-	route.Cluster = cluster.Name
-	route.clusters = []*Cluster{cluster}
-	route.WebsocketUpgrade = true
-	if rule.Rewrite != nil && rule.Rewrite.GetUri() != "" {
-		// overwrite the computed prefix with the rewritten prefix,
-		// for this is what we expect from remote envoys
-		route.Prefix = rule.Rewrite.GetUri()
-		route.Path = ""
-	}
-
-	return route
-}
-
 func buildInboundRoute(config model.Config, rule *proxyconfig.RouteRule, cluster *Cluster) *HTTPRoute {
 	route := buildHTTPRouteMatch(rule.Match)
 	route.Cluster = cluster.Name
 	route.clusters = []*Cluster{cluster}
+	route.WebsocketUpgrade = rule.WebsocketUpgrade
 	if rule.Rewrite != nil && rule.Rewrite.GetUri() != "" {
 		// overwrite the computed prefix with the rewritten prefix,
 		// for this is what we expect from remote envoys
@@ -94,7 +80,9 @@ func buildInboundRoute(config model.Config, rule *proxyconfig.RouteRule, cluster
 		route.Path = ""
 	}
 
-	route.Decorator = buildDecorator(config)
+	if !rule.WebsocketUpgrade {
+		route.Decorator = buildDecorator(config)
+	}
 
 	return route
 }

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -237,7 +237,7 @@ func buildCluster(address, name string, timeout *duration.Duration) *Cluster {
 func buildDecorator(config model.Config) *Decorator {
 	if config.ConfigMeta.Name != "" {
 		return &Decorator{
-			Operation:             config.ConfigMeta.Name,
+			Operation: config.ConfigMeta.Name,
 		}
 	}
 	return nil

--- a/proxy/envoy/testdata/lds-v0-egress-rule-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-egress-rule-auth.json.golden
@@ -317,6 +317,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -536,6 +539,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v0-egress-rule-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-egress-rule-nomixer.json.golden
@@ -248,7 +248,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.1081"
+            "cluster": "in.1081",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }
@@ -392,7 +395,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.80"
+            "cluster": "in.80",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }

--- a/proxy/envoy/testdata/lds-v0-egress-rule.json.golden
+++ b/proxy/envoy/testdata/lds-v0-egress-rule.json.golden
@@ -317,6 +317,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -512,6 +515,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
@@ -329,6 +329,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -548,6 +551,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v0-fault-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault-nomixer.json.golden
@@ -276,7 +276,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.1081"
+            "cluster": "in.1081",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }
@@ -420,7 +423,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.80"
+            "cluster": "in.80",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }

--- a/proxy/envoy/testdata/lds-v0-fault.json.golden
+++ b/proxy/envoy/testdata/lds-v0-fault.json.golden
@@ -329,6 +329,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -524,6 +527,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v0-none-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none-auth.json.golden
@@ -265,6 +265,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -484,6 +487,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v0-none-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none-nomixer.json.golden
@@ -212,7 +212,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.1081"
+            "cluster": "in.1081",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }
@@ -356,7 +359,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.80"
+            "cluster": "in.80",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }

--- a/proxy/envoy/testdata/lds-v0-none.json.golden
+++ b/proxy/envoy/testdata/lds-v0-none.json.golden
@@ -265,6 +265,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -460,6 +463,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
@@ -265,6 +265,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -484,6 +487,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v0-weighted-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted-nomixer.json.golden
@@ -212,7 +212,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.1081"
+            "cluster": "in.1081",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }
@@ -356,7 +359,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.80"
+            "cluster": "in.80",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }

--- a/proxy/envoy/testdata/lds-v0-weighted.json.golden
+++ b/proxy/envoy/testdata/lds-v0-weighted.json.golden
@@ -265,6 +265,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -460,6 +463,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v1-egress-rule-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-egress-rule-auth.json.golden
@@ -317,6 +317,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -536,6 +539,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v1-egress-rule-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-egress-rule-nomixer.json.golden
@@ -248,7 +248,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.1081"
+            "cluster": "in.1081",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }
@@ -392,7 +395,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.80"
+            "cluster": "in.80",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }

--- a/proxy/envoy/testdata/lds-v1-egress-rule.json.golden
+++ b/proxy/envoy/testdata/lds-v1-egress-rule.json.golden
@@ -317,6 +317,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -512,6 +515,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
@@ -265,6 +265,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -484,6 +487,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v1-fault-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault-nomixer.json.golden
@@ -212,7 +212,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.1081"
+            "cluster": "in.1081",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }
@@ -356,7 +359,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.80"
+            "cluster": "in.80",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }

--- a/proxy/envoy/testdata/lds-v1-fault.json.golden
+++ b/proxy/envoy/testdata/lds-v1-fault.json.golden
@@ -265,6 +265,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -460,6 +463,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v1-none-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none-auth.json.golden
@@ -265,6 +265,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -484,6 +487,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v1-none-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none-nomixer.json.golden
@@ -212,7 +212,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.1081"
+            "cluster": "in.1081",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }
@@ -356,7 +359,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.80"
+            "cluster": "in.80",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }

--- a/proxy/envoy/testdata/lds-v1-none.json.golden
+++ b/proxy/envoy/testdata/lds-v1-none.json.golden
@@ -265,6 +265,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -460,6 +463,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
@@ -265,6 +265,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -484,6 +487,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-v1-weighted-nomixer.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted-nomixer.json.golden
@@ -212,7 +212,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.1081"
+            "cluster": "in.1081",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }
@@ -356,7 +359,10 @@
           "routes": [
            {
             "prefix": "/",
-            "cluster": "in.80"
+            "cluster": "in.80",
+            "decorator": {
+             "operation": "default-route"
+            }
            }
           ]
          }

--- a/proxy/envoy/testdata/lds-v1-weighted.json.golden
+++ b/proxy/envoy/testdata/lds-v1-weighted.json.golden
@@ -265,6 +265,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -460,6 +463,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/lds-websocket.json.golden
+++ b/proxy/envoy/testdata/lds-websocket.json.golden
@@ -275,6 +275,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]
@@ -480,6 +483,9 @@
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
             }
            }
           ]

--- a/proxy/envoy/testdata/rds-fault.json.golden
+++ b/proxy/envoy/testdata/rds-fault.json.golden
@@ -80,7 +80,10 @@
         "name": "scooby",
         "value": "doo"
        }
-      ]
+      ],
+      "decorator": {
+       "operation": "fault"
+      }
      },
      {
       "prefix": "/",

--- a/proxy/envoy/testdata/rds-fault.json.golden
+++ b/proxy/envoy/testdata/rds-fault.json.golden
@@ -19,7 +19,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -41,7 +44,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -87,7 +93,10 @@
      },
      {
       "prefix": "/",
-      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
+      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-httpproxy.json.golden
+++ b/proxy/envoy/testdata/rds-httpproxy.json.golden
@@ -8,7 +8,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.55be44fb22f17cf2c3204372ebee71e7723bcb1c"
+      "cluster": "out.55be44fb22f17cf2c3204372ebee71e7723bcb1c",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -21,7 +24,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.241817cc0b7d464b36565d486ed22d9494b67a27"
+      "cluster": "out.241817cc0b7d464b36565d486ed22d9494b67a27",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -33,7 +39,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.02875f9311443c8773650d3fa21cee271505806f"
+      "cluster": "out.02875f9311443c8773650d3fa21cee271505806f",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -56,7 +65,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -73,7 +85,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.81c187d71467b1608736c57bb0734f9ef9b68f7d"
+      "cluster": "out.81c187d71467b1608736c57bb0734f9ef9b68f7d",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -95,7 +110,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -112,7 +130,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpsbin.default.svc.cluster.local",
-      "cluster": "out.242bc3028e0f3fe0682e6d972e167ab415b2321d"
+      "cluster": "out.242bc3028e0f3fe0682e6d972e167ab415b2321d",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -135,7 +156,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
+      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -152,7 +176,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.bde94496eb59ec2ed5b81392a1d32377960660b8"
+      "cluster": "out.bde94496eb59ec2ed5b81392a1d32377960660b8",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-ingress-ssl.json.golden
+++ b/proxy/envoy/testdata/rds-ingress-ssl.json.golden
@@ -13,6 +13,9 @@
        "mixer_check": "on",
        "mixer_forward": "on",
        "mixer_report": "on"
+      },
+      "decorator": {
+       "operation": "default-route"
       }
      }
     ]

--- a/proxy/envoy/testdata/rds-ingress-weighted.json.golden
+++ b/proxy/envoy/testdata/rds-ingress-weighted.json.golden
@@ -25,6 +25,9 @@
        "mixer_check": "on",
        "mixer_forward": "on",
        "mixer_report": "on"
+      },
+      "decorator": {
+       "operation": "weighted"
       }
      }
     ]

--- a/proxy/envoy/testdata/rds-ingress.json.golden
+++ b/proxy/envoy/testdata/rds-ingress.json.golden
@@ -14,6 +14,9 @@
        "mixer_check": "on",
        "mixer_forward": "on",
        "mixer_report": "on"
+      },
+      "decorator": {
+       "operation": "default-route"
       }
      }
     ]

--- a/proxy/envoy/testdata/rds-redirect.json.golden
+++ b/proxy/envoy/testdata/rds-redirect.json.golden
@@ -81,7 +81,10 @@
         "name": "scooby",
         "value": "doo"
        }
-      ]
+      ],
+      "decorator": {
+       "operation": "redirect"
+      }
      },
      {
       "prefix": "/",

--- a/proxy/envoy/testdata/rds-redirect.json.golden
+++ b/proxy/envoy/testdata/rds-redirect.json.golden
@@ -19,7 +19,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -41,7 +44,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -88,7 +94,10 @@
      },
      {
       "prefix": "/",
-      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
+      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-rewrite.json.golden
+++ b/proxy/envoy/testdata/rds-rewrite.json.golden
@@ -66,7 +66,10 @@
       "prefix": "/old/path",
       "prefix_rewrite": "/new/path",
       "host_rewrite": "foo.bar.com",
-      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
+      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74",
+      "decorator": {
+       "operation": "rewrite"
+      }
      },
      {
       "prefix": "/",

--- a/proxy/envoy/testdata/rds-rewrite.json.golden
+++ b/proxy/envoy/testdata/rds-rewrite.json.golden
@@ -19,7 +19,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -41,7 +44,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -73,7 +79,10 @@
      },
      {
       "prefix": "/",
-      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
+      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-router-weighted.json.golden
+++ b/proxy/envoy/testdata/rds-router-weighted.json.golden
@@ -19,7 +19,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -41,7 +44,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -75,6 +81,9 @@
          "weight": 25
         }
        ]
+      },
+      "decorator": {
+       "operation": "weighted"
       }
      }
     ]

--- a/proxy/envoy/testdata/rds-timeout.json.golden
+++ b/proxy/envoy/testdata/rds-timeout.json.golden
@@ -15,6 +15,9 @@
        "retry_on": "5xx,connect-failure,refused-stream",
        "num_retries": 1,
        "per_try_timeout_ms": 5000
+      },
+      "decorator": {
+       "operation": "egress-timeout"
       }
      }
     ]
@@ -89,6 +92,9 @@
        "retry_on": "5xx,connect-failure,refused-stream",
        "num_retries": 1,
        "per_try_timeout_ms": 5000
+      },
+      "decorator": {
+       "operation": "timeout"
       }
      }
     ]

--- a/proxy/envoy/testdata/rds-timeout.json.golden
+++ b/proxy/envoy/testdata/rds-timeout.json.golden
@@ -41,7 +41,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -63,7 +66,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },

--- a/proxy/envoy/testdata/rds-v0-nomixer.json.golden
+++ b/proxy/envoy/testdata/rds-v0-nomixer.json.golden
@@ -9,7 +9,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.241817cc0b7d464b36565d486ed22d9494b67a27"
+      "cluster": "out.241817cc0b7d464b36565d486ed22d9494b67a27",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -32,7 +35,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -54,7 +60,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -77,7 +86,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
+      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-v0-status.json.golden
+++ b/proxy/envoy/testdata/rds-v0-status.json.golden
@@ -19,7 +19,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.81c187d71467b1608736c57bb0734f9ef9b68f7d"
+      "cluster": "out.81c187d71467b1608736c57bb0734f9ef9b68f7d",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -42,7 +45,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.bde94496eb59ec2ed5b81392a1d32377960660b8"
+      "cluster": "out.bde94496eb59ec2ed5b81392a1d32377960660b8",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-v0.json.golden
+++ b/proxy/envoy/testdata/rds-v0.json.golden
@@ -19,7 +19,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -41,7 +44,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -64,7 +70,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
+      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-v1.json.golden
+++ b/proxy/envoy/testdata/rds-v1.json.golden
@@ -19,7 +19,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -41,7 +44,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -64,7 +70,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
+      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-websocket.json.golden
+++ b/proxy/envoy/testdata/rds-websocket.json.golden
@@ -20,7 +20,10 @@
      {
       "prefix": "/websocket",
       "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
-      "use_websocket": true
+      "use_websocket": true,
+      "decorator": {
+       "operation": "websocket"
+      }
      },
      {
       "prefix": "/",

--- a/proxy/envoy/testdata/rds-websocket.json.golden
+++ b/proxy/envoy/testdata/rds-websocket.json.golden
@@ -27,7 +27,10 @@
      },
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -49,7 +52,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -72,7 +78,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74"
+      "cluster": "out.a2263b90cd24e500e9ed95f79ae47eabdc77dc74",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-weighted.json.golden
+++ b/proxy/envoy/testdata/rds-weighted.json.golden
@@ -75,6 +75,9 @@
          "weight": 25
         }
        ]
+      },
+      "decorator": {
+       "operation": "weighted"
       }
      }
     ]

--- a/proxy/envoy/testdata/rds-weighted.json.golden
+++ b/proxy/envoy/testdata/rds-weighted.json.golden
@@ -19,7 +19,10 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },
@@ -41,7 +44,10 @@
      {
       "prefix": "/",
       "host_rewrite": "httpbin.default.svc.cluster.local",
-      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e",
+      "decorator": {
+       "operation": "default-route"
+      }
      }
     ]
    },


### PR DESCRIPTION
**What this PR does / why we need it**: Uses the route name as the span/operation name in the tracing data.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
If this PR is accepted, I would propose doing a separate PR with an update to the bookinfo example to show how individual routes could be named (using business relevant terms) based on specific REST endpoints.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
The operation/span name in the tracing data now uses the route name, allowing business relevant names to be associated with the tracing information. Individual routes could be defined for each REST endpoint, allowing them to be individually named.
```
