### PR TITLE
Fix eurekamirror build in `gocompile-and-push-images.sh` script

### DIFF
--- a/bin/gocompile-and-push-images.sh
+++ b/bin/gocompile-and-push-images.sh
@@ -46,6 +46,7 @@ go build ./cmd/pilot-discovery
 go build ./cmd/sidecar-initializer
 go build ./test/server
 go build ./test/client
+go build ./test/eurekamirror
 
 # Collect artifacts for pushing
 cp -f  client docker/client
@@ -53,6 +54,7 @@ cp -f  server docker/server
 cp -f  pilot-agent docker/pilot-agent
 cp -f  pilot-discovery docker/pilot-discovery
 cp -f  sidecar-initializer docker/sidecar-initializer
+cp -f  eurekamirror docker/eurekamirror
 
 # Build and push images
 if [[ "$hub" =~ ^gcr\.io ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**: Eureka mirror was missing from part of the `gocompile-and-push-images.sh` script

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
