### PR TITLE
Add liveness and readiness to Ingress and Egress

### DIFF
--- a/test/integration/testdata/egress-proxy.yaml.tmpl
+++ b/test/integration/testdata/egress-proxy.yaml.tmpl
@@ -63,7 +63,7 @@ spec:
             - -c
             - curl http://localhost:15000/clusters
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 20
           timeoutSeconds: 3
           failureThreshold: 10
         env:

--- a/test/integration/testdata/egress-proxy.yaml.tmpl
+++ b/test/integration/testdata/egress-proxy.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
           exec:
             command:
             - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
-          initialDelaySeconds: 10
+          initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 3
           failureThreshold: 10
@@ -58,7 +58,7 @@ spec:
           exec:
             command:
             - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
-          initialDelaySeconds: 15
+          initialDelaySeconds: 5
           periodSeconds: 5
           timeoutSeconds: 3
           failureThreshold: 10

--- a/test/integration/testdata/egress-proxy.yaml.tmpl
+++ b/test/integration/testdata/egress-proxy.yaml.tmpl
@@ -49,6 +49,8 @@ spec:
         readinessProbe:
           exec:
             command:
+            - /bin/sh
+            - -c
             - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
           initialDelaySeconds: 3
           periodSeconds: 5
@@ -57,7 +59,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
+            - /bin/sh
+            - -c
+            - curl http://localhost:15000/clusters
           initialDelaySeconds: 5
           periodSeconds: 5
           timeoutSeconds: 3

--- a/test/integration/testdata/egress-proxy.yaml.tmpl
+++ b/test/integration/testdata/egress-proxy.yaml.tmpl
@@ -54,7 +54,7 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 3
           failureThreshold: 10
-        livelinessProbe:
+        livenessProbe:
           exec:
             command:
             - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes

--- a/test/integration/testdata/egress-proxy.yaml.tmpl
+++ b/test/integration/testdata/egress-proxy.yaml.tmpl
@@ -46,6 +46,22 @@ spec:
         - --zipkinAddress
         - zipkin:9411
 {{end}}
+        readinessProbe:
+          exec:
+            command:
+            - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 10
+        livelinessProbe:
+          exec:
+            command:
+            - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 10
         env:
         - name: POD_NAME
           valueFrom:

--- a/test/integration/testdata/ingress-proxy.yaml.tmpl
+++ b/test/integration/testdata/ingress-proxy.yaml.tmpl
@@ -67,7 +67,7 @@ spec:
             - -c
             - curl http://localhost:15000/clusters
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 20
           timeoutSeconds: 3
           failureThreshold: 10
         env:

--- a/test/integration/testdata/ingress-proxy.yaml.tmpl
+++ b/test/integration/testdata/ingress-proxy.yaml.tmpl
@@ -58,7 +58,7 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 3
           failureThreshold: 10
-        livelinessProbe:
+        livenessProbe:
           exec:
             command:
             - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes

--- a/test/integration/testdata/ingress-proxy.yaml.tmpl
+++ b/test/integration/testdata/ingress-proxy.yaml.tmpl
@@ -53,6 +53,8 @@ spec:
         readinessProbe:
           exec:
             command:
+            - /bin/sh
+            - -c
             - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
           initialDelaySeconds: 3
           periodSeconds: 5
@@ -61,7 +63,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
+            - /bin/sh
+            - -c
+            - curl http://localhost:15000/clusters
           initialDelaySeconds: 5
           periodSeconds: 5
           timeoutSeconds: 3

--- a/test/integration/testdata/ingress-proxy.yaml.tmpl
+++ b/test/integration/testdata/ingress-proxy.yaml.tmpl
@@ -54,7 +54,7 @@ spec:
           exec:
             command:
             - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
-          initialDelaySeconds: 10
+          initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 3
           failureThreshold: 10
@@ -62,7 +62,7 @@ spec:
           exec:
             command:
             - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
-          initialDelaySeconds: 15
+          initialDelaySeconds: 5
           periodSeconds: 5
           timeoutSeconds: 3
           failureThreshold: 10

--- a/test/integration/testdata/ingress-proxy.yaml.tmpl
+++ b/test/integration/testdata/ingress-proxy.yaml.tmpl
@@ -50,6 +50,22 @@ spec:
         ports:
         - containerPort: 443
         - containerPort: 80
+        readinessProbe:
+          exec:
+            command:
+            - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 10
+        livelinessProbe:
+          exec:
+            command:
+            - curl http://localhost:15000/clusters && curl http://localhost:15000/listeners && curl http://localhost:15000/routes
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 10
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
Reduce likelihood of 404 for Ingress and Egress by ensuring the container does not receive traffic when envoy does not run istio/istio#1038

Matches istio/istio#1055

The perfect fix is ADS, which will come later.