### PR TITLE
Enable ingress mode for Eureka/Consul

### DIFF
--- a/proxy/context.go
+++ b/proxy/context.go
@@ -73,8 +73,8 @@ const (
 	// Egress type is used for cluster egress proxies
 	Egress NodeType = "egress"
 
-	// LB type is used for load balancer mode
-	LB NodeType = "lb"
+	// Router type is used for standalone proxies acting as L7/L4 routers
+	Router NodeType = "router"
 )
 
 // ServiceNode encodes the proxy node attributes into a URI-acceptable string

--- a/proxy/context.go
+++ b/proxy/context.go
@@ -72,6 +72,9 @@ const (
 
 	// Egress type is used for cluster egress proxies
 	Egress NodeType = "egress"
+
+	// LB type is used for load balancer mode
+	LB NodeType = "lb"
 )
 
 // ServiceNode encodes the proxy node attributes into a URI-acceptable string

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -117,7 +117,7 @@ func buildConfig(listeners Listeners, clusters Clusters, lds bool, config proxyc
 // buildListeners produces a list of listeners and referenced clusters for all proxies
 func buildListeners(env proxy.Environment, node proxy.Node) Listeners {
 	switch node.Type {
-	case proxy.Sidecar, proxy.LB:
+	case proxy.Sidecar, proxy.Router:
 		instances := env.HostInstances(map[string]bool{node.IPAddress: true})
 		listeners, _ := buildSidecarListenersClusters(env.Mesh, instances,
 			env.Services(), env.ManagementPorts(node.IPAddress), node, env.IstioConfigStore)
@@ -135,7 +135,7 @@ func buildClusters(env proxy.Environment, node proxy.Node) Clusters {
 	var clusters Clusters
 	var instances []*model.ServiceInstance
 	switch node.Type {
-	case proxy.Sidecar, proxy.LB:
+	case proxy.Sidecar, proxy.Router:
 		instances = env.HostInstances(map[string]bool{node.IPAddress: true})
 		_, clusters = buildSidecarListenersClusters(env.Mesh, instances,
 			env.Services(), env.ManagementPorts(node.IPAddress), node, env.IstioConfigStore)
@@ -180,7 +180,7 @@ func buildSidecarListenersClusters(
 	listeners := make(Listeners, 0)
 	clusters := make(Clusters, 0)
 
-	if node.Type == proxy.LB {
+	if node.Type == proxy.Router {
 		outbound, outClusters := buildOutboundListeners(mesh, node, instances, services, config)
 		listeners = append(listeners, outbound...)
 		clusters = append(clusters, outClusters...)
@@ -227,14 +227,24 @@ func buildSidecarListenersClusters(
 
 	// enable HTTP PROXY port if necessary; this will add an RDS route for this port
 	if mesh.ProxyHttpPort > 0 {
+		useRemoteAddress := false
+		traceOperation := EgressTraceOperation
+		listenAddress := LocalhostAddress
+
+		if node.Type == proxy.Router {
+			useRemoteAddress = true
+			traceOperation = IngressTraceOperation
+			listenAddress = WildcardAddress
+		}
+
 		// only HTTP outbound clusters are needed
 		httpOutbound := buildOutboundHTTPRoutes(mesh, node, instances, services, config)
-		httpOutbound = buildEgressFromSidecarHTTPRoutes(mesh, instances, config, httpOutbound)
+		httpOutbound = buildEgressHTTPRoutes(mesh, node, instances, config, httpOutbound)
 		clusters = append(clusters,
 			httpOutbound.clusters()...)
 		listeners = append(listeners,
-			buildHTTPListener(mesh, node, instances, nil, LocalhostAddress, int(mesh.ProxyHttpPort),
-				RDSAll, false, EgressTraceOperation))
+			buildHTTPListener(mesh, node, instances, nil, listenAddress, int(mesh.ProxyHttpPort),
+				RDSAll, useRemoteAddress, traceOperation))
 		// TODO: need inbound listeners in HTTP_PROXY case, with dedicated ingress listener.
 	}
 
@@ -254,11 +264,11 @@ func buildRDSRoute(mesh *proxyconfig.MeshConfig, node proxy.Node, routeName stri
 		httpConfigs, _ = buildIngressRoutes(mesh, instances, discovery, config)
 	case proxy.Egress:
 		httpConfigs = buildEgressRoutes(mesh, discovery)
-	case proxy.Sidecar, proxy.LB:
+	case proxy.Sidecar, proxy.Router:
 		instances := discovery.HostInstances(map[string]bool{node.IPAddress: true})
 		services := discovery.Services()
 		httpConfigs = buildOutboundHTTPRoutes(mesh, node, instances, services, config)
-		httpConfigs = buildEgressFromSidecarHTTPRoutes(mesh, instances, config, httpConfigs)
+		httpConfigs = buildEgressHTTPRoutes(mesh, node, instances, config, httpConfigs)
 	default:
 		return nil
 	}
@@ -436,23 +446,24 @@ func buildTCPListener(tcpConfig *TCPRouteConfig, ip string, port int, protocol m
 // buildOutboundListeners combines HTTP routes and TCP listeners
 func buildOutboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node, instances []*model.ServiceInstance,
 	services []*model.Service, config model.IstioConfigStore) (Listeners, Clusters) {
-	listeners, clusters := buildOutboundTCPListeners(mesh, services)
+	listeners, clusters := buildOutboundTCPListeners(mesh, sidecar, services)
 
 	// note that outbound HTTP routes are supplied through RDS
 	httpOutbound := buildOutboundHTTPRoutes(mesh, sidecar, instances, services, config)
-	httpOutbound = buildEgressFromSidecarHTTPRoutes(mesh, instances, config, httpOutbound)
+	httpOutbound = buildEgressHTTPRoutes(mesh, sidecar, instances, config, httpOutbound)
 
 	for port, routeConfig := range httpOutbound {
-		var l *Listener
-		if sidecar.Type == proxy.LB {
-			// if this is in LB mode, then use ingress style trace operation, and remote address settings
-			l = buildHTTPListener(mesh, sidecar, instances, routeConfig, WildcardAddress, port,
-				fmt.Sprintf("%d", port), true, IngressTraceOperation)
-		} else {
-			l = buildHTTPListener(mesh, sidecar, instances, routeConfig, WildcardAddress, port,
-				fmt.Sprintf("%d", port), false, EgressTraceOperation)
+		operation := EgressTraceOperation
+		useRemoteAddress := false
+
+		if sidecar.Type == proxy.Router {
+			// if this is in Router mode, then use ingress style trace operation, and remote address settings
+			useRemoteAddress = true
+			operation = IngressTraceOperation
 		}
 
+		l := buildHTTPListener(mesh, sidecar, instances, routeConfig, WildcardAddress, port,
+			fmt.Sprintf("%d", port), useRemoteAddress, operation)
 		listeners = append(listeners, l)
 		clusters = append(clusters, routeConfig.clusters()...)
 	}
@@ -581,7 +592,8 @@ func buildOutboundHTTPRoutes(mesh *proxyconfig.MeshConfig, sidecar proxy.Node,
 // Connections to the ports of non-load balanced services are directed to
 // the connection's original destination. This avoids costly queries of instance
 // IPs and ports, but requires that ports of non-load balanced service be unique.
-func buildOutboundTCPListeners(mesh *proxyconfig.MeshConfig, services []*model.Service) (Listeners, Clusters) {
+func buildOutboundTCPListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node,
+	services []*model.Service) (Listeners, Clusters) {
 	tcpListeners := make(Listeners, 0)
 	tcpClusters := make(Clusters, 0)
 
@@ -594,8 +606,11 @@ func buildOutboundTCPListeners(mesh *proxyconfig.MeshConfig, services []*model.S
 		for _, servicePort := range service.Ports {
 			switch servicePort.Protocol {
 			case model.ProtocolTCP, model.ProtocolHTTPS, model.ProtocolMongo, model.ProtocolRedis:
-				if service.LoadBalancingDisabled || service.Address == "" {
-					// ensure only one wildcard listener is created per port
+				if service.LoadBalancingDisabled || service.Address == "" ||
+					sidecar.Type == proxy.Router {
+					// ensure only one wildcard listener is created per port if its headless service
+					// or if its for a Router (where there is one wildcard TCP listener per port)
+					// or if this is in environment where services don't get a dummy load balancer IP.
 					if wildcardListenerPorts[servicePort.Port] {
 						glog.V(4).Infof("Multiple definitions for port %d", servicePort.Port)
 						continue
@@ -603,7 +618,8 @@ func buildOutboundTCPListeners(mesh *proxyconfig.MeshConfig, services []*model.S
 					wildcardListenerPorts[servicePort.Port] = true
 
 					var cluster *Cluster
-					if service.LoadBalancingDisabled {
+					// Router mode cannot handle headless services
+					if service.LoadBalancingDisabled && sidecar.Type != proxy.Router {
 						if originalDstCluster == nil {
 							originalDstCluster = buildOriginalDSTCluster(
 								"orig-dst-cluster-tcp", mesh.ConnectTimeout)
@@ -618,6 +634,9 @@ func buildOutboundTCPListeners(mesh *proxyconfig.MeshConfig, services []*model.S
 					config := &TCPRouteConfig{Routes: []*TCPRoute{route}}
 					listener := buildTCPListener(
 						config, WildcardAddress, servicePort.Port, servicePort.Protocol)
+					if sidecar.Type == proxy.Router {
+						listener.BindToPort = true
+					}
 					tcpListeners = append(tcpListeners, listener)
 				} else {
 					cluster := buildOutboundCluster(service.Hostname, servicePort, nil)
@@ -748,7 +767,7 @@ func appendPortToDomains(domains []string, port int) []string {
 	return domainsWithPorts
 }
 
-func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule,
+func buildEgressVirtualHost(rule *proxyconfig.EgressRule,
 	mesh *proxyconfig.MeshConfig, port *model.Port, instances []*model.ServiceInstance,
 	config model.IstioConfigStore) *VirtualHost {
 	var externalTrafficCluster *Cluster
@@ -759,27 +778,21 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule,
 		protocolToHandle = model.ProtocolHTTP2
 	}
 
-	if rule.UseEgressProxy {
-		externalTrafficCluster = buildOutboundCluster("istio-egress", port, nil)
-		externalTrafficCluster.Type = ClusterTypeStrictDNS
-		externalTrafficCluster.Hosts = []Host{{URL: fmt.Sprintf("tcp://%s", mesh.EgressProxyAddress)}}
-	} else {
-		// Create a unique orig dst cluster for each service defined by egress rule
-		// So that we can apply circuit breakers, outlier detections, etc., later.
-		svc := model.Service{Hostname: destination}
-		key := svc.Key(port, nil)
-		name := fmt.Sprintf("%x", sha1.Sum([]byte(key)))
-		externalTrafficCluster = buildOriginalDSTCluster(name, mesh.ConnectTimeout)
-		externalTrafficCluster.ServiceName = key
-		externalTrafficCluster.hostname = destination
-		externalTrafficCluster.port = port
-		if protocolToHandle == model.ProtocolHTTPS {
-			externalTrafficCluster.SSLContext = &SSLContextExternal{}
-		}
+	// Create a unique orig dst cluster for each service defined by egress rule
+	// So that we can apply circuit breakers, outlier detections, etc., later.
+	svc := model.Service{Hostname: destination}
+	key := svc.Key(port, nil)
+	name := fmt.Sprintf("%x", sha1.Sum([]byte(key)))
+	externalTrafficCluster = buildOriginalDSTCluster(name, mesh.ConnectTimeout)
+	externalTrafficCluster.ServiceName = key
+	externalTrafficCluster.hostname = destination
+	externalTrafficCluster.port = port
+	if protocolToHandle == model.ProtocolHTTPS {
+		externalTrafficCluster.SSLContext = &SSLContextExternal{}
+	}
 
-		if protocolToHandle == model.ProtocolHTTP2 {
-			externalTrafficCluster.Features = ClusterFeatureHTTP2
-		}
+	if protocolToHandle == model.ProtocolHTTP2 {
+		externalTrafficCluster.Features = ClusterFeatureHTTP2
 	}
 
 	if protocolToHandle == model.ProtocolHTTPS {
@@ -810,8 +823,14 @@ func buildEgressFromSidecarVirtualHostOnPort(rule *proxyconfig.EgressRule,
 	}
 }
 
-func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.MeshConfig, instances []*model.ServiceInstance,
-	config model.IstioConfigStore, httpConfigs HTTPRouteConfigs) HTTPRouteConfigs {
+func buildEgressHTTPRoutes(mesh *proxyconfig.MeshConfig, node proxy.Node,
+	instances []*model.ServiceInstance, config model.IstioConfigStore,
+	httpConfigs HTTPRouteConfigs) HTTPRouteConfigs {
+
+	if node.Type == proxy.Router {
+		// No egress rule support for Routers. As semantics are not clear.
+		return httpConfigs
+	}
 
 	egressRules, errs := model.RejectConflictingEgressRules(config.EgressRules())
 
@@ -831,7 +850,7 @@ func buildEgressFromSidecarHTTPRoutes(mesh *proxyconfig.MeshConfig, instances []
 				Port: intPort, Protocol: protocol}
 			httpConfig := httpConfigs.EnsurePort(intPort)
 			httpConfig.VirtualHosts = append(httpConfig.VirtualHosts,
-				buildEgressFromSidecarVirtualHostOnPort(rule, mesh, modelPort, instances, config))
+				buildEgressVirtualHost(rule, mesh, modelPort, instances, config))
 		}
 	}
 

--- a/proxy/envoy/config_test.go
+++ b/proxy/envoy/config_test.go
@@ -317,17 +317,17 @@ func addConfig(r model.ConfigStore, config fileConfig, t *testing.T) {
 
 func makeProxyConfig() proxyconfig.ProxyConfig {
 	mesh := proxy.DefaultProxyConfig()
-	mesh.ZipkinAddress = "localhost:6000"
+	mesh.ZipkinAddress = "zipkin.istio-system:6000"
 	mesh.StatsdUdpAddress = "10.1.1.10:9125"
-	mesh.DiscoveryAddress = "localhost:8080"
+	mesh.DiscoveryAddress = "istio-pilot.istio-system:8080"
 	mesh.DiscoveryRefreshDelay = ptypes.DurationProto(10 * time.Millisecond)
 	return mesh
 }
 
 func makeMeshConfig() proxyconfig.MeshConfig {
 	mesh := proxy.DefaultMeshConfig()
-	mesh.MixerAddress = "localhost:9091"
-	mesh.EgressProxyAddress = "localhost:8888"
+	mesh.MixerAddress = "istio-mixer.istio-system:9091"
+	mesh.EgressProxyAddress = "istio-egress.istio-system:8888"
 	mesh.RdsRefreshDelay = ptypes.DurationProto(10 * time.Millisecond)
 	return mesh
 }

--- a/proxy/envoy/discovery_test.go
+++ b/proxy/envoy/discovery_test.go
@@ -183,6 +183,13 @@ func TestClusterDiscoveryIstioEgress(t *testing.T) {
 	compareResponse(response, "testdata/cds-istio-egress.json", t)
 }
 
+func TestClusterDiscoveryRouter(t *testing.T) {
+	_, _, ds := commonSetup(t)
+	url := fmt.Sprintf("/v1/clusters/%s/%s", "istio-proxy", mock.Router.ServiceNode())
+	response := makeDiscoveryRequest(ds, "GET", url, t)
+	compareResponse(response, "testdata/cds-router.json", t)
+}
+
 // Test listing all routes
 func TestRouteDiscoveryAllRoutes(t *testing.T) {
 	_, _, ds := commonSetup(t)
@@ -311,6 +318,15 @@ func TestRouteDiscoveryIngressWeighted(t *testing.T) {
 	compareResponse(response, "testdata/rds-ingress-weighted.json", t)
 }
 
+func TestRouteDiscoveryRouterWeighted(t *testing.T) {
+	_, registry, ds := commonSetup(t)
+	addConfig(registry, weightedRouteRule, t)
+
+	url := fmt.Sprintf("/v1/routes/80/%s/%s", "istio-proxy", mock.Router.ServiceNode())
+	response := makeDiscoveryRequest(ds, "GET", url, t)
+	compareResponse(response, "testdata/rds-router-weighted.json", t)
+}
+
 func TestRouteDiscoveryIstioEgress(t *testing.T) {
 	_, _, ds := commonSetup(t)
 
@@ -319,7 +335,7 @@ func TestRouteDiscoveryIstioEgress(t *testing.T) {
 	compareResponse(response, "testdata/rds-istio-egress.json", t)
 }
 
-func TestSidecarListenerDiscovery(t *testing.T) {
+func TestListenerDiscoverySidecar(t *testing.T) {
 	testCases := []struct {
 		name string
 		file fileConfig
@@ -450,6 +466,21 @@ func TestListenerDiscoveryIstioEgress(t *testing.T) {
 	ds = makeDiscoveryService(t, registry, &mesh)
 	response = makeDiscoveryRequest(ds, "GET", url, t)
 	compareResponse(response, "testdata/lds-istio-egress-auth.json", t)
+}
+
+func TestListenerDiscoveryRouter(t *testing.T) {
+	mesh := makeMeshConfig()
+	registry := memory.Make(model.IstioConfigTypes)
+	ds := makeDiscoveryService(t, registry, &mesh)
+	addConfig(registry, egressRule, t)
+	url := fmt.Sprintf("/v1/listeners/%s/%s", "istio-proxy", mock.Router.ServiceNode())
+	response := makeDiscoveryRequest(ds, "GET", url, t)
+	compareResponse(response, "testdata/lds-router.json", t)
+
+	mesh.AuthPolicy = proxyconfig.MeshConfig_MUTUAL_TLS
+	ds = makeDiscoveryService(t, registry, &mesh)
+	response = makeDiscoveryRequest(ds, "GET", url, t)
+	compareResponse(response, "testdata/lds-router-auth.json", t)
 }
 
 func TestDiscoveryCache(t *testing.T) {

--- a/proxy/envoy/testdata/cds-circuit-breaker.json.golden
+++ b/proxy/envoy/testdata/cds-circuit-breaker.json.golden
@@ -141,7 +141,7 @@
     "lb_type": "round_robin",
     "hosts": [
      {
-      "url": "tcp://localhost:8888"
+      "url": "tcp://istio-egress.istio-system:8888"
      }
     ]
    },
@@ -230,7 +230,7 @@
     "lb_type": "round_robin",
     "hosts": [
      {
-      "url": "tcp://localhost:8888"
+      "url": "tcp://istio-egress.istio-system:8888"
      }
     ]
    },
@@ -283,7 +283,7 @@
     "lb_type": "round_robin",
     "hosts": [
      {
-      "url": "tcp://localhost:9091"
+      "url": "tcp://istio-mixer.istio-system:9091"
      }
     ],
     "features": "http2",

--- a/proxy/envoy/testdata/cds-ingress.json.golden
+++ b/proxy/envoy/testdata/cds-ingress.json.golden
@@ -21,7 +21,7 @@
     "lb_type": "round_robin",
     "hosts": [
      {
-      "url": "tcp://localhost:9091"
+      "url": "tcp://istio-mixer.istio-system:9091"
      }
     ],
     "features": "http2",

--- a/proxy/envoy/testdata/cds-istio-egress.json.golden
+++ b/proxy/envoy/testdata/cds-istio-egress.json.golden
@@ -30,7 +30,7 @@
     "lb_type": "round_robin",
     "hosts": [
      {
-      "url": "tcp://localhost:9091"
+      "url": "tcp://istio-mixer.istio-system:9091"
      }
     ],
     "features": "http2",

--- a/proxy/envoy/testdata/cds-router.json.golden
+++ b/proxy/envoy/testdata/cds-router.json.golden
@@ -1,97 +1,6 @@
 {
   "clusters": [
    {
-    "name": "in.1081",
-    "connect_timeout_ms": 1000,
-    "type": "static",
-    "lb_type": "round_robin",
-    "hosts": [
-     {
-      "url": "tcp://127.0.0.1:1081"
-     }
-    ]
-   },
-   {
-    "name": "in.1090",
-    "connect_timeout_ms": 1000,
-    "type": "static",
-    "lb_type": "round_robin",
-    "hosts": [
-     {
-      "url": "tcp://127.0.0.1:1090"
-     }
-    ]
-   },
-   {
-    "name": "in.1100",
-    "connect_timeout_ms": 1000,
-    "type": "static",
-    "lb_type": "round_robin",
-    "hosts": [
-     {
-      "url": "tcp://127.0.0.1:1100"
-     }
-    ]
-   },
-   {
-    "name": "in.1110",
-    "connect_timeout_ms": 1000,
-    "type": "static",
-    "lb_type": "round_robin",
-    "hosts": [
-     {
-      "url": "tcp://127.0.0.1:1110"
-     }
-    ]
-   },
-   {
-    "name": "in.3333",
-    "connect_timeout_ms": 1000,
-    "type": "static",
-    "lb_type": "round_robin",
-    "hosts": [
-     {
-      "url": "tcp://127.0.0.1:3333"
-     }
-    ]
-   },
-   {
-    "name": "in.80",
-    "connect_timeout_ms": 1000,
-    "type": "static",
-    "lb_type": "round_robin",
-    "hosts": [
-     {
-      "url": "tcp://127.0.0.1:80"
-     }
-    ]
-   },
-   {
-    "name": "in.9999",
-    "connect_timeout_ms": 1000,
-    "type": "static",
-    "lb_type": "round_robin",
-    "hosts": [
-     {
-      "url": "tcp://127.0.0.1:9999"
-     }
-    ]
-   },
-   {
-    "name": "out.12a577b4dd04c9a3fed313fc71fb850e7f9c345f",
-    "service_name": "world.default.svc.cluster.local|redis",
-    "connect_timeout_ms": 1000,
-    "type": "sds",
-    "lb_type": "round_robin"
-   },
-   {
-    "name": "out.152eb365b2958596c93b3d847abe47b5bc3f1e9a",
-    "service_name": "world.default.svc.cluster.local|mongo",
-    "connect_timeout_ms": 1000,
-    "type": "sds",
-    "lb_type": "round_robin"
-   },
-   {
     "name": "out.242bc3028e0f3fe0682e6d972e167ab415b2321d",
     "connect_timeout_ms": 1000,
     "type": "strict_dns",
@@ -101,13 +10,6 @@
       "url": "tcp://istio-egress.istio-system:8888"
      }
     ]
-   },
-   {
-    "name": "out.5898aa4379cc19c8f1bb3b7915ee8e0e32ddc6a6",
-    "service_name": "world.default.svc.cluster.local|custom",
-    "connect_timeout_ms": 1000,
-    "type": "sds",
-    "lb_type": "round_robin"
    },
    {
     "name": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890",

--- a/proxy/envoy/testdata/cds-ssl-context.json.golden
+++ b/proxy/envoy/testdata/cds-ssl-context.json.golden
@@ -131,7 +131,7 @@
     "lb_type": "round_robin",
     "hosts": [
      {
-      "url": "tcp://localhost:8888"
+      "url": "tcp://istio-egress.istio-system:8888"
      }
     ],
     "ssl_context": {
@@ -227,7 +227,7 @@
     "lb_type": "round_robin",
     "hosts": [
      {
-      "url": "tcp://localhost:8888"
+      "url": "tcp://istio-egress.istio-system:8888"
      }
     ],
     "ssl_context": {
@@ -286,7 +286,7 @@
     "lb_type": "round_robin",
     "hosts": [
      {
-      "url": "tcp://localhost:9091"
+      "url": "tcp://istio-mixer.istio-system:9091"
      }
     ],
     "features": "http2",

--- a/proxy/envoy/testdata/envoy.json.golden
+++ b/proxy/envoy/testdata/envoy.json.golden
@@ -17,7 +17,7 @@
         "lb_type": "round_robin",
         "hosts": [
           {
-            "url": "tcp://localhost:8080"
+            "url": "tcp://istio-pilot.istio-system:8080"
           }
         ]
       },
@@ -28,7 +28,7 @@
         "lb_type": "round_robin",
         "hosts": [
           {
-            "url": "tcp://localhost:8080"
+            "url": "tcp://istio-pilot.istio-system:8080"
           }
         ]
       },
@@ -39,7 +39,7 @@
         "lb_type": "round_robin",
         "hosts": [
           {
-            "url": "tcp://localhost:6000"
+            "url": "tcp://zipkin.istio-system:6000"
           }
         ]
       }
@@ -52,7 +52,7 @@
         "lb_type": "round_robin",
         "hosts": [
           {
-            "url": "tcp://localhost:8080"
+            "url": "tcp://istio-pilot.istio-system:8080"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "lb_type": "round_robin",
         "hosts": [
           {
-            "url": "tcp://localhost:8080"
+            "url": "tcp://istio-pilot.istio-system:8080"
           }
         ]
       },

--- a/proxy/envoy/testdata/lds-router-auth.json.golden
+++ b/proxy/envoy/testdata/lds-router-auth.json.golden
@@ -1,0 +1,227 @@
+{
+  "listeners": [
+   {
+    "address": "tcp://0.0.0.0:100",
+    "name": "mongo_0.0.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890"
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:110",
+    "name": "redis_0.0.0.0_110",
+    "filters": [
+     {
+      "type": "both",
+      "name": "redis_proxy",
+      "config": {
+       "cluster_name": "out.ad08e00d6d07a7cdbdbacfc83fef3fd62aaa4c26",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
+      }
+     }
+    ],
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:443",
+    "name": "http_0.0.0.0_443",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "use_remote_address": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "443",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "mixer_attributes": {
+           "destination.ip": "10.3.3.5",
+           "destination.uid": "kubernetes://router.default"
+          },
+          "forward_attributes": {
+           "source.ip": "10.3.3.5",
+           "source.uid": "kubernetes://router.default"
+          },
+          "quota_name": "RequestCount"
+         }
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:80",
+    "name": "http_0.0.0.0_80",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "use_remote_address": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "80",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "mixer_attributes": {
+           "destination.ip": "10.3.3.5",
+           "destination.uid": "kubernetes://router.default"
+          },
+          "forward_attributes": {
+           "source.ip": "10.3.3.5",
+           "source.uid": "kubernetes://router.default"
+          },
+          "quota_name": "RequestCount"
+         }
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:81",
+    "name": "http_0.0.0.0_81",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "use_remote_address": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "81",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "mixer_attributes": {
+           "destination.ip": "10.3.3.5",
+           "destination.uid": "kubernetes://router.default"
+          },
+          "forward_attributes": {
+           "source.ip": "10.3.3.5",
+           "source.uid": "kubernetes://router.default"
+          },
+          "quota_name": "RequestCount"
+         }
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:90",
+    "name": "tcp_0.0.0.0_90",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.de6d66d4dd5f542e5f61882eb466189eb68ebe88"
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": true
+   }
+  ]
+ }

--- a/proxy/envoy/testdata/lds-router.json.golden
+++ b/proxy/envoy/testdata/lds-router.json.golden
@@ -1,0 +1,227 @@
+{
+  "listeners": [
+   {
+    "address": "tcp://0.0.0.0:100",
+    "name": "mongo_0.0.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.6fc71bd0fc240b9cf1b3437a82c18a5c97d40890"
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:110",
+    "name": "redis_0.0.0.0_110",
+    "filters": [
+     {
+      "type": "both",
+      "name": "redis_proxy",
+      "config": {
+       "cluster_name": "out.ad08e00d6d07a7cdbdbacfc83fef3fd62aaa4c26",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
+      }
+     }
+    ],
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:443",
+    "name": "http_0.0.0.0_443",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "use_remote_address": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "443",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "mixer_attributes": {
+           "destination.ip": "10.3.3.5",
+           "destination.uid": "kubernetes://router.default"
+          },
+          "forward_attributes": {
+           "source.ip": "10.3.3.5",
+           "source.uid": "kubernetes://router.default"
+          },
+          "quota_name": "RequestCount"
+         }
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:80",
+    "name": "http_0.0.0.0_80",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "use_remote_address": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "80",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "mixer_attributes": {
+           "destination.ip": "10.3.3.5",
+           "destination.uid": "kubernetes://router.default"
+          },
+          "forward_attributes": {
+           "source.ip": "10.3.3.5",
+           "source.uid": "kubernetes://router.default"
+          },
+          "quota_name": "RequestCount"
+         }
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:81",
+    "name": "http_0.0.0.0_81",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "use_remote_address": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "81",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "mixer_attributes": {
+           "destination.ip": "10.3.3.5",
+           "destination.uid": "kubernetes://router.default"
+          },
+          "forward_attributes": {
+           "source.ip": "10.3.3.5",
+           "source.uid": "kubernetes://router.default"
+          },
+          "quota_name": "RequestCount"
+         }
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:90",
+    "name": "tcp_0.0.0.0_90",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.de6d66d4dd5f542e5f61882eb466189eb68ebe88"
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": true
+   }
+  ]
+ }

--- a/proxy/envoy/testdata/rds-router-weighted.json.golden
+++ b/proxy/envoy/testdata/rds-router-weighted.json.golden
@@ -1,0 +1,83 @@
+{
+  "virtual_hosts": [
+   {
+    "name": "hello.default.svc.cluster.local|http",
+    "domains": [
+     "hello:80",
+     "hello",
+     "hello.default:80",
+     "hello.default",
+     "hello.default.svc:80",
+     "hello.default.svc",
+     "hello.default.svc.cluster:80",
+     "hello.default.svc.cluster",
+     "hello.default.svc.cluster.local:80",
+     "hello.default.svc.cluster.local",
+     "10.1.0.0:80",
+     "10.1.0.0"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.e5c9564b7c4dbb0355a4f740e9d29277ccca97cd"
+     }
+    ]
+   },
+   {
+    "name": "httpbin.default.svc.cluster.local|http",
+    "domains": [
+     "httpbin:80",
+     "httpbin",
+     "httpbin.default:80",
+     "httpbin.default",
+     "httpbin.default.svc:80",
+     "httpbin.default.svc",
+     "httpbin.default.svc.cluster:80",
+     "httpbin.default.svc.cluster",
+     "httpbin.default.svc.cluster.local:80",
+     "httpbin.default.svc.cluster.local"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "host_rewrite": "httpbin.default.svc.cluster.local",
+      "cluster": "out.ae8d3361601f8293abe6ac5e4d807124612cf42e"
+     }
+    ]
+   },
+   {
+    "name": "world.default.svc.cluster.local|http",
+    "domains": [
+     "world:80",
+     "world",
+     "world.default:80",
+     "world.default",
+     "world.default.svc:80",
+     "world.default.svc",
+     "world.default.svc.cluster:80",
+     "world.default.svc.cluster",
+     "world.default.svc.cluster.local:80",
+     "world.default.svc.cluster.local",
+     "10.2.0.0:80",
+     "10.2.0.0"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "weighted_clusters": {
+       "clusters": [
+        {
+         "name": "out.c76febe0f151b2f8abe0f377d2052c0fbbfb959d",
+         "weight": 75
+        },
+        {
+         "name": "out.66fcc955b8875b19844f9eaf6cfda47c778c609e",
+         "weight": 25
+        }
+       ]
+      }
+     }
+    ]
+   }
+  ]
+ }

--- a/test/mock/service.go
+++ b/test/mock/service.go
@@ -72,6 +72,12 @@ var (
 		ID:        "egress.default",
 		Domain:    "default.svc.cluster.local",
 	}
+	Router = proxy.Node{
+		Type:      proxy.Router,
+		IPAddress: "10.3.3.5",
+		ID:        "router.default",
+		Domain:    "default.svc.cluster.local",
+	}
 )
 
 // NewDiscovery builds a mock ServiceDiscovery


### PR DESCRIPTION
**What this PR does / why we need it**:
Ingress is a generic concept applicable across platforms. K8S has ingress as first class resource (except its broken in several ways). In non k8s platforms, we cannot use this ingress resource spec reliably, as it requires enabling ingress controller without the status syncer (adds more complexities), especially if people are just adding it for the dummy ingress.

This PR defines a new proxy agent mode (LB) that allows the sidecar to obtain just outbound configs, and run as standalone envoy [which becomes ingress in Consul/Eureka]. With this, we would no longer have to expose services directly (like the way we do today). An added benefit is that this would allow people to run envoy as standalone using load balancer service in kubernetes, with support for TCP and HTTP services.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
new Load Balancer mode for sidecar to enable ingress functionality in non-k8s environments
```
