### PR TITLE
fix for istio-initializer needs to ignore hostNetwork pod specs (#1440)

### DIFF
--- a/platform/kube/inject/inject_test.go
+++ b/platform/kube/inject/inject_test.go
@@ -152,6 +152,10 @@ func TestIntoResourceFile(t *testing.T) {
 			in:   "testdata/replicationcontroller.yaml",
 			want: "testdata/replicationcontroller.yaml.injected",
 		},
+		{
+			in:   "testdata/hello-host-network.yaml",
+			want: "testdata/hello-host-network.yaml.injected",
+		},
 	}
 
 	for _, c := range cases {

--- a/platform/kube/inject/testdata/hello-host-network.yaml
+++ b/platform/kube/inject/testdata/hello-host-network.yaml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hello-host-network
+spec:
+  replicas: 7
+  template:
+    metadata:
+      labels:
+        app: hello-host-network
+        tier: backend
+        track: stable
+    spec:
+      containers:
+        - name: hello-host-network
+          image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+          ports:
+            - name: http
+              containerPort: 80
+      hostNetwork: true

--- a/platform/kube/inject/testdata/hello-host-network.yaml.injected
+++ b/platform/kube/inject/testdata/hello-host-network.yaml.injected
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: hello-host-network
+spec:
+  replicas: 7
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: hello-host-network
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello-host-network
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      hostNetwork: true
+status: {}
+---


### PR DESCRIPTION
Automatic merge from submit-queue

fix for istio-initializer needs to ignore hostNetwork pod specs

**What this PR does / why we need it**:

PR for https://github.com/istio/istio.github.io/issues/655, see #655 for details

**Release note**:

```release-note
When a pod uses hostNetwork: true, the pod will be disabled from side car injection on purpose because we don't want the envoy side car to change the network configuration at the host level.
```

**Special notes for your reviewer**:
This is the same PR but for 0.2 release branch.
