### PR TITLE
fix `Error: an empty namespace may not be set during creation` bug

### DIFF
--- a/adapter/config/crd/conversion.go
+++ b/adapter/config/crd/conversion.go
@@ -56,10 +56,14 @@ func ConvertConfig(schema model.ProtoSchema, config model.Config) (IstioObject, 
 	if err != nil {
 		return nil, err
 	}
+	namespace := config.Namespace
+	if namespace == "" {
+		namespace = meta_v1.NamespaceDefault
+	}
 	out := knownTypes[schema.Type].object.DeepCopyObject().(IstioObject)
 	out.SetObjectMeta(meta_v1.ObjectMeta{
 		Name:            config.Name,
-		Namespace:       config.Namespace,
+		Namespace:       namespace,
 		ResourceVersion: config.ResourceVersion,
 		Labels:          config.Labels,
 		Annotations:     config.Annotations,


### PR DESCRIPTION
The crd client code uses the object namespace in rest
calls. Kubernetes expects this namespace to be non-empty. Add the
"default" namespace when the namespace is omitted during model-to-crd
conversion to satisfy this condition.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1472 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
