### PR TITLE
let getDefaultNamespace() returns "default" if nothing is found.

### DIFF
--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -697,7 +697,11 @@ func getDefaultNamespace(kubeconfig string) string {
 		return v1.NamespaceDefault
 	}
 
-	return config.Contexts[config.CurrentContext].Namespace
+	namespace := config.Contexts[config.CurrentContext].Namespace
+	if namespace == "" {
+		return v1.NamespaceDefault
+	}
+	return namespace
 }
 
 func handleNamespaces(objectNamespace string) (string, error) {


### PR DESCRIPTION
https://github.com/istio/issues/issues/110 reminds me that istioctl
can set empty namespace for mixer configs, which will be delivered
directly and therefore it can cause same error of "empty namespace".

When the obtained namespace happens to be empty, I think it should
return the default value.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1637

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
