### PR TITLE
Adding alpn_protocols for listener ssl context

### DIFF
--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -44,6 +44,7 @@ func buildIngressListeners(mesh *proxyconfig.MeshConfig,
 		listener.SSLContext = &SSLContext{
 			CertChainFile:  path.Join(proxy.IngressCertsPath, proxy.IngressCertFilename),
 			PrivateKeyFile: path.Join(proxy.IngressCertsPath, proxy.IngressKeyFilename),
+			AlpnProtocols:  ListenersAlpnProtocols,
 		}
 		listeners = append(listeners, listener)
 	}

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -113,6 +113,10 @@ const (
 	// ZipkinCollectorEndpoint denotes the REST endpoint where Envoy posts Zipkin spans
 	ZipkinCollectorEndpoint = "/api/v1/spans"
 
+	// ListenersAlpnProtocols denotes the the list of ALPN protocols that the listener
+	// should expose
+	ListenersAlpnProtocols = "h2,http/1.1"
+
 	router  = "router"
 	auto    = "auto"
 	decoder = "decoder"
@@ -596,6 +600,7 @@ type SSLContext struct {
 	PrivateKeyFile           string `json:"private_key_file"`
 	CaCertFile               string `json:"ca_cert_file,omitempty"`
 	RequireClientCertificate bool   `json:"require_client_certificate"`
+	AlpnProtocols            string `json:"alpn_protocols,omitempty"`
 }
 
 // SSLContextExternal definition

--- a/proxy/envoy/testdata/lds-ingress.json.golden
+++ b/proxy/envoy/testdata/lds-ingress.json.golden
@@ -151,7 +151,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/istio/ingress-certs/tls.crt",
      "private_key_file": "/etc/istio/ingress-certs/tls.key",
-     "require_client_certificate": false
+     "require_client_certificate": false,
+     "alpn_protocols": "h2,http/1.1"
     },
     "bind_to_port": true
    }


### PR DESCRIPTION
**What this PR does / why we need it**:
@rshriram  This PR adds the param "alpn_protocols" for listener ssl context as documented here - https://www.envoyproxy.io/envoy/configuration/listeners/ssl.html#config-listener-ssl-context
Currently grpc-java clients require that the proxy return a selected alpn_protocol else it errors out.
The discussion on this issue is detailed here - https://groups.google.com/forum/#!topic/istio-users/MYRflKPQRkA
I am intentionally leaving the cluster ssl context untouched here.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Let me know if any additional tests need to be added. I ran the e2etests which passed successfully. I also functionally validated it against the grpc-java client server where I had initially seen the issue and it worked successfully this time.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
