### PR TITLE
fix nil pointer dereference when current kubectl context is empty

### DIFF
--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -697,11 +697,14 @@ func getDefaultNamespace(kubeconfig string) string {
 		return v1.NamespaceDefault
 	}
 
-	namespace := config.Contexts[config.CurrentContext].Namespace
-	if namespace == "" {
+	context, ok := config.Contexts[config.CurrentContext]
+	if !ok {
 		return v1.NamespaceDefault
 	}
-	return namespace
+	if context.Namespace == "" {
+		return v1.NamespaceDefault
+	}
+	return context.Namespace
 }
 
 func handleNamespaces(objectNamespace string) (string, error) {


### PR DESCRIPTION
The following panic occurs if kubectl's current-context does not point
to a valid configuration context.

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x11f2018]

    goroutine 1 [running]:
    main.getDefaultNamespace(0xc4202cc280, 0x12, 0x0, 0x0)
    cmd/istioctl/main.go:700 +0xb8
    main.glob..func4(0x1c35de0, 0x1c61be8, 0x0, 0x0)
    cmd/istioctl/main.go:86 +0x39
    github.com/spf13/cobra.(*Command).execute(0x1c35de0, 0x1c61be8, 0x0, 0x0, 0x1c35de0, 0x1c61be8)
    external/com_github_spf13_cobra/command.go:637 +0x549
    github.com/spf13/cobra.(*Command).ExecuteC(0x1c349a0, 0x41172d, 0xc4200002a8, 0x0)
    external/com_github_spf13_cobra/command.go:729 +0x339
    github.com/spf13/cobra.(*Command).Execute(0x1c349a0, 0xc4204f7f78, 0x434056)
    external/com_github_spf13_cobra/command.go:688 +0x2b
    main.main()
    cmd/istioctl/main.go:531 +0xc0

fixes https://github.com/istio/issues/issues/105

```release-note
NONE
```
