### PR TITLE
Adding support for alpn protocols in listener ssl context

### DIFF
--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"strings"
 
 	"github.com/golang/glog"
 
@@ -44,6 +45,7 @@ func buildIngressListeners(mesh *proxyconfig.MeshConfig,
 		listener.SSLContext = &SSLContext{
 			CertChainFile:  path.Join(proxy.IngressCertsPath, proxy.IngressCertFilename),
 			PrivateKeyFile: path.Join(proxy.IngressCertsPath, proxy.IngressKeyFilename),
+			ALPNProtocols:  strings.Join(ListenersALPNProtocols, ","),
 		}
 		listeners = append(listeners, listener)
 	}

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -120,6 +120,10 @@ const (
 	both    = "both"
 )
 
+// ListenersALPNProtocols denotes the the list of ALPN protocols that the listener
+// should expose
+var ListenersALPNProtocols = []string{"h2", "http/1.1"}
+
 // convertDuration converts to golang duration and logs errors
 func convertDuration(d *duration.Duration) time.Duration {
 	dur, err := ptypes.Duration(d)
@@ -589,6 +593,7 @@ type SSLContext struct {
 	PrivateKeyFile           string `json:"private_key_file"`
 	CaCertFile               string `json:"ca_cert_file,omitempty"`
 	RequireClientCertificate bool   `json:"require_client_certificate"`
+	ALPNProtocols            string `json:"alpn_protocols,omitempty"`
 }
 
 // SSLContextExternal definition

--- a/proxy/envoy/testdata/lds-ingress.json.golden
+++ b/proxy/envoy/testdata/lds-ingress.json.golden
@@ -105,7 +105,8 @@
     "ssl_context": {
      "cert_chain_file": "/etc/istio/ingress-certs/tls.crt",
      "private_key_file": "/etc/istio/ingress-certs/tls.key",
-     "require_client_certificate": false
+     "require_client_certificate": false,
+     "alpn_protocols": "h2,http/1.1"
     },
     "bind_to_port": true
    }


### PR DESCRIPTION
**What this PR does / why we need it**:
@rkpagadala @linsun @rshriram This PR adds the param "alpn_protocols" for listener ssl context as documented here - https://www.envoyproxy.io/envoy/configuration/listeners/ssl.html#config-listener-ssl-context
Currently grpc-java clients require that the proxy return a selected alpn_protocol else it errors out.
The discussion on this issue is detailed here - https://groups.google.com/forum/#!topic/istio-users/MYRflKPQRkA
I am intentionally leaving the cluster ssl context untouched here.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
These changes have been merged into master branch in the istio/istio repo - https://github.com/istio/istio/pull/1294
Without this PR we are currently blocked on using any grpc-java service over TLS with Istio, hence we would be grateful if this gets merged into the next 0.2 release.
 
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
